### PR TITLE
fix preserveResolvers argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,15 +77,15 @@ const types = require('./types');
 const mocks = require('./mocks');
 
 class PropertyComponent extends GraphQLComponent {
-  constructor({ useMocks, preserveTypeResolvers }) {
-    super({ types, resolvers, mocks, useMocks, preserveTypeResolvers });
+  constructor({ useMocks, preserveResolvers }) {
+    super({ types, resolvers, mocks, useMocks, preserveResolvers });
   }
 }
 
 module.exports = PropertyComponent;
 ```
 
-This will allow for configuration (in this example, `useMocks` and `preserveTypeResolvers`) as well as instance data per component (such as data base clients, etc).
+This will allow for configuration (in this example, `useMocks` and `preserveResolvers`) as well as instance data per component (such as data base clients, etc).
 
 ### Aggregation
 
@@ -212,7 +212,7 @@ Example extending `Property` to include a `reviews` field that delegates to anot
 
 ```javascript
 class PropertyComponentReviews extends GraphQLComponent {
-  constructor({ useMocks, preserveTypeResolvers }) {
+  constructor({ useMocks, preserveResolvers }) {
     const propertyComponent = new PropertyComponent();
     const reviewsComponent = new ReviewsComponent();
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -8,7 +8,7 @@ interface ComponentOptions {
   directives?: any;
   context?: any;
   useMocks?: boolean;
-  preserveTypeResolvers?: boolean;
+  preserveResolvers?: boolean;
   dataSources?: any[];
   dataSourceOverrides?: any;
   federation?: boolean;

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,7 @@ class GraphQLComponent {
     directives = undefined,
     context = undefined,
     useMocks = false,
-    preserveTypeResolvers = false,
+    preserveResolvers = false,
     dataSourceOverrides = [],
     federation = false
   } = {}) {
@@ -93,7 +93,7 @@ class GraphQLComponent {
     this._useMocks = useMocks;
     this._importedMocks = Object.assign({}, ...this._imports.map((c) => ({ ...c.mocks, ...c._importedMocks})));
     this._mocks = mocks && mocks(this._importedMocks);
-    this._preserveTypeResolvers = preserveTypeResolvers;
+    this._preserveResolvers = preserveResolvers;
 
     this._mergedTypes = mergeTypeDefs([...this._importedTypes, ...this._types]);
     this._mergedResolvers = mergeResolvers([this._importedResolvers, this._resolvers]);
@@ -132,11 +132,11 @@ class GraphQLComponent {
     debug(`created ${this.constructor.name} schema`);
 
     if (this._useMocks) {
-      debug(`adding mocks, preserveTypeResolvers=${this._preserveTypeResolvers}`);
+      debug(`adding mocks, preserveResolvers=${this._preserveResolvers}`);
 
       const mocks = Object.assign({}, this._importedMocks, this._mocks);
 
-      addMockFunctionsToSchema({ schema, mocks, preserveTypeResolvers: this._preserveTypeResolvers });
+      addMockFunctionsToSchema({ schema, mocks, preserveResolvers: this._preserveResolvers });
     }
 
     this._schema = schema;

--- a/test/examples/composition/server/index.js
+++ b/test/examples/composition/server/index.js
@@ -4,7 +4,7 @@ const ListingComponent = require('../listing-component');
 
 const { schema, context} = new ListingComponent({ 
   useMocks: !!process.env.GRAPHQL_MOCK, 
-  preserveTypeResolvers: true,
+  preserveResolvers: true,
   //Data source overriding
   dataSourceOverrides: [
     new class MockDataSource {


### PR DESCRIPTION
Was doing some cleanup work on `hapi-graphql-bootstrap`'s options and figured out that the wrong key is being passed to `addMockFunctionsToSchema()`. According to the apollo docs for [addMockFunctionsToSchema()](https://www.apollographql.com/docs/apollo-server/api/graphql-tools/#addmockfunctiontoschemaoptions) the key is `preserveResolvers` instead of `preserveTypeResolvers`.