### PR TITLE
Execute errors

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,3 +7,4 @@ azure-pipelines.yml
 .eslintrc
 .github
 .nycrc
+.dockerignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 ### Unreleased
 
-- [BREAKING] Execute inlines errors to facilitate returning multiple errors from resolver
+- Execute flag `mergeErrors` allows inline errors to facilitate returning multiple errors from resolvers that use `execute`.
 
 ### v1.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Unreleased
+
+- [BREAKING] Execute inlines errors to facilitate returning multiple errors from resolver
+
 ### v1.2.0
 
 - Added federation support

--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ const { schema, context } = new GraphQLComponent({
 
 Components can be directly executed via the `execute` function. The `execute` function is basically a passthrough to `graphql.execute` and is mostly useful for components calling imported components and the like.
 
+The `execute` function will return an object representing the result of the call, and may contain errors as field values. These errors will be propagated to the errors list in the graphql response when the result is returned.
+
 For example, this allows one component to invoke another component and still get the benefits of that component's schema type resolvers and validation.
 
 `execute(input, options)` accepts an `input` string and an optional `options` object with the following fields:
@@ -205,6 +207,8 @@ For example, this allows one component to invoke another component and still get
 - `root` - root object.
 - `context` - context object value.
 - `variables` - key:value mapping of variables for the input.
+
+Returns an object containing results and may contain errors on field values.
 
 The `execute` function also adds some helper fragments. For any type you query in a component, a helper fragment will exist to query all fields.
 
@@ -223,10 +227,9 @@ class PropertyComponentReviews extends GraphQLComponent {
       resolvers: {
         Property: {
           async reviews(_, args, context) {
-            //TODO: error handle here of course!
-            const { data } = return reviewsComponent.execute(`query { reviewsByPropertyId(id: ${_.id}) { ...AllReview }}`, { context });
+            const { reviewsByPropertyId } = await reviewsComponent.execute(`query { reviewsByPropertyId(id: ${_.id}) { ...AllReview }}`, { context });
 
-            return data.reviewsByPropertyId;
+            return reviewsByPropertyId;
           }
         }
       },

--- a/README.md
+++ b/README.md
@@ -207,8 +207,11 @@ For example, this allows one component to invoke another component and still get
 - `root` - root object.
 - `context` - context object value.
 - `variables` - key:value mapping of variables for the input.
+- `mergeErrors` - merge errors and data together.
 
-Returns an object containing results and may contain errors on field values.
+Returns an object containing `data` and `errors`. 
+
+If `mergeErrors: true`, returns an object containing the result and may contain errors on field values.
 
 The `execute` function also adds some helper fragments. For any type you query in a component, a helper fragment will exist to query all fields.
 
@@ -227,7 +230,7 @@ class PropertyComponentReviews extends GraphQLComponent {
       resolvers: {
         Property: {
           async reviews(_, args, context) {
-            const { reviewsByPropertyId } = await reviewsComponent.execute(`query { reviewsByPropertyId(id: ${_.id}) { ...AllReview }}`, { context });
+            const { reviewsByPropertyId } = await reviewsComponent.execute(`query { reviewsByPropertyId(id: ${_.id}) { ...AllReview }}`, { context, mergeErrors: true });
 
             return reviewsByPropertyId;
           }

--- a/lib/index.js
+++ b/lib/index.js
@@ -107,19 +107,23 @@ class GraphQLComponent {
     return check && check._types && check._resolvers && check._imports;
   }
 
-  async execute(input, { root = undefined, context = this._context, variables = {} } = {}) {
+  async execute(input, { mergeErrors = false, root = undefined, context = this._context, variables = {} } = {}) {
     const document = typeof input === 'string' ? gql`${this._fragments.join('\n')}\n${input}` : input;
     
     const { data = {}, errors = [] } = await graphql.execute({ document, schema: this.schema, rootValue: root, contextValue: context, variableValues: variables });
 
-    //Maps errors on to the result object
-    if (errors.length > 0) {
-      for (const error of errors) {
-        deepSet(data, error.path, error);
+    if (mergeErrors === true) {
+      //Maps errors on to the result object
+      if (errors.length > 0) {
+        for (const error of errors) {
+          deepSet(data, error.path, error);
+        }
       }
-    }
 
-    return data;
+      return data;
+    }
+    
+    return { data, errors };
   }
 
   makeFederatedSchemaWithDirectives({typeDefs, resolvers, schemaDirectives}) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -107,25 +107,14 @@ class GraphQLComponent {
     return check && check._types && check._resolvers && check._imports;
   }
 
-  async execute(input, { root = undefined, context = {}, variables = {}, fieldMap = {} } = {}) {
+  async execute(input, { root = undefined, context = {}, variables = {} } = {}) {
     const document = typeof input === 'string' ? gql`${this._fragments.join('\n')}\n${input}` : input;
 
     const { data = {}, errors = [] } = await graphql.execute({ document, schema: this.schema, rootValue: root, contextValue: context, variableValues: variables });
 
-    for (const [oldField, newField] of Object.entries(fieldMap)) {
-      if (Object.keys(data).indexOf(oldField) === -1) {
-        continue;
-      }
-      data[newField] = data[oldField];
-      delete data[oldField];
-    }
-
     //Maps errors on to the result object
     if (errors.length > 0) {
       for (const error of errors) {
-        if (fieldMap[error.path[0]]) {
-          error.path[0] = fieldMap[error.path[0]];
-        }
         deepSet(data, error.path, error);
       }
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,7 @@ const { buildFragments } = require('./fragments');
 const { mergeDirectives, getImportedDirectives } = require('./directives');
 const { createDataSourceInjection } = require('./datasource');
 const cuid = require('cuid');
+const deepSet = require('lodash.set');
 
 const debug = require('debug')('graphql-component:schema');
 
@@ -106,10 +107,30 @@ class GraphQLComponent {
     return check && check._types && check._resolvers && check._imports;
   }
 
-  execute(input, { root = undefined, context = {}, variables = {} } = {}) {
+  async execute(input, { root = undefined, context = {}, variables = {}, fieldMap = {} } = {}) {
     const document = typeof input === 'string' ? gql`${this._fragments.join('\n')}\n${input}` : input;
-    
-    return graphql.execute({ document, schema: this.schema, rootValue: root, contextValue: context, variableValues: variables });
+
+    const { data = {}, errors = [] } = await graphql.execute({ document, schema: this.schema, rootValue: root, contextValue: context, variableValues: variables });
+
+    for (const [oldField, newField] of Object.entries(fieldMap)) {
+      if (Object.keys(data).indexOf(oldField) === -1) {
+        continue;
+      }
+      data[newField] = data[oldField];
+      delete data[oldField];
+    }
+
+    //Maps errors on to the result object
+    if (errors.length > 0) {
+      for (const error of errors) {
+        if (fieldMap[error.path[0]]) {
+          error.path[0] = fieldMap[error.path[0]];
+        }
+        deepSet(data, error.path, error);
+      }
+    }
+
+    return data;
   }
 
   get schema() {

--- a/lib/index.js
+++ b/lib/index.js
@@ -107,7 +107,7 @@ class GraphQLComponent {
     return check && check._types && check._resolvers && check._imports;
   }
 
-  async execute(input, { root = undefined, context = {}, variables = {} } = {}) {
+  async execute(input, { root = undefined, context = this._context, variables = {} } = {}) {
     const document = typeof input === 'string' ? gql`${this._fragments.join('\n')}\n${input}` : input;
 
     const { data = {}, errors = [] } = await graphql.execute({ document, schema: this.schema, rootValue: root, contextValue: context, variableValues: variables });

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "graphql-extensions": "^0.5.2",
     "graphql-tag": "^2.10.1",
     "graphql-toolkit": "^0.5.0",
-    "graphql-tools": "^4.0.5"
+    "graphql-tools": "^4.0.5",
+    "lodash.set": "^4.3.2"
   },
   "peerDependencies": {
     "graphql": "^14.0"

--- a/test/test-directives.js
+++ b/test/test-directives.js
@@ -90,7 +90,7 @@ Test('test componentA', async (t) => {
       }
     `;
 
-    const result = await componentA.execute(query);
+    const result = await componentA.execute(query, { mergeErrors: true });
 
     t.deepEqual(result, { book: { id: '1', title: 'Some Title' } }, 'has result');
   });
@@ -133,7 +133,7 @@ Test('test componentB', async (t) => {
       }
     `;
 
-    const result = await componentB.execute(query);
+    const result = await componentB.execute(query, { mergeErrors: true });
 
     t.deepEqual(result, { author: { id: '1', name: 'Some Author' } }, 'has result');
   });
@@ -242,5 +242,5 @@ Test('namespace directives execution', (t) => {
     }
   });
 
-  component.execute(`query thing { aField, bField }`);
+  component.execute(`query thing { aField, bField }`, { mergeErrors: true });
 });

--- a/test/test-directives.js
+++ b/test/test-directives.js
@@ -82,7 +82,7 @@ Test('test componentA', async (t) => {
   });
 
   t.test('componentA execute', async (t) => {
-    t.plan(3);
+    t.plan(1);
 
     const query = `
       query {
@@ -92,9 +92,7 @@ Test('test componentA', async (t) => {
 
     const result = await componentA.execute(query);
 
-    t.ok(result, 'has result');
-    t.ok(result.data, 'data returned');
-    t.error(result.errors, 'no errors');
+    t.deepEqual(result, { book: { id: '1', title: 'Some Title' } }, 'has result');
   });
 });
 
@@ -127,19 +125,17 @@ Test('test componentB', async (t) => {
   });
 
   t.test('componentB execute', async (t) => {
-    t.plan(3);
+    t.plan(1);
 
     const query = `
       query {
-        author(id: 1) {id, name, books}
+        author(id: 1) {id, name}
       }
     `;
 
     const result = await componentB.execute(query);
 
-    t.ok(result, 'has result');
-    t.ok(result.data, 'data returned');
-    t.error(result.errors, 'no errors');
+    t.deepEqual(result, { author: { id: '1', name: 'Some Author' } }, 'has result');
   });
 });
 

--- a/test/test-execute.js
+++ b/test/test-execute.js
@@ -33,7 +33,7 @@ Test('test component execute', (t) => {
   });
 
   t.test('execute query', async (t) => {
-    t.plan(1);
+    t.plan(2);
 
     const query = `
       query {
@@ -43,9 +43,10 @@ Test('test component execute', (t) => {
       }
     `;
 
-    const result = await component.execute(query);
+    const { data, errors } = await component.execute(query);
 
-    t.deepEqual(result, { book: { title: 'Some Title' } }, 'has result');
+    t.deepEqual(data, { book: { title: 'Some Title' } }, 'has result');
+    t.equal(errors.length, 0, 'no errors');
   });
 
   t.test('execute query with document object', async (t) => {
@@ -59,12 +60,29 @@ Test('test component execute', (t) => {
       }
     `;
 
-    const result = await component.execute(query);
+    const result = await component.execute(query, { mergeErrors: true });
 
     t.deepEqual(result, { book: { title: 'Some Title' } }, 'has result');
   });
 
   t.test('execute error', async (t) => {
+    t.plan(2);
+
+    const query = `
+      query {
+        book {
+          title
+        }
+      }
+    `;
+
+    const { data, errors } = await component.execute(query);
+
+    t.ok(data);
+    t.ok(errors && errors.length === 1, 'error');
+  });
+
+  t.test('execute error merged', async (t) => {
     t.plan(1);
 
     const query = `
@@ -75,7 +93,7 @@ Test('test component execute', (t) => {
       }
     `;
 
-    const result = await component.execute(query);
+    const result = await component.execute(query, { mergeErrors: true });
 
     t.ok(result.book instanceof Error, 'error');
   });
@@ -95,7 +113,7 @@ Test('test component execute', (t) => {
       }
     `;
 
-    const result = await component.execute(query);
+    const result = await component.execute(query, { mergeErrors: true });
 
     t.deepEqual(result, { one: { title: 'Some Title' }, two: { id: '2', title: 'Some Title' } }, 'data returned');
   });

--- a/test/test-execute.js
+++ b/test/test-execute.js
@@ -33,7 +33,7 @@ Test('test component execute', (t) => {
   });
 
   t.test('execute query', async (t) => {
-    t.plan(3);
+    t.plan(1);
 
     const query = `
       query {
@@ -45,13 +45,11 @@ Test('test component execute', (t) => {
 
     const result = await component.execute(query);
 
-    t.ok(result, 'has result');
-    t.ok(result.data, 'data returned');
-    t.error(result.errors, 'no errors');
+    t.deepEqual(result, { book: { title: 'Some Title' } }, 'has result');
   });
 
   t.test('execute query with document object', async (t) => {
-    t.plan(3);
+    t.plan(1);
 
     const query = gql`
       query {
@@ -63,9 +61,7 @@ Test('test component execute', (t) => {
 
     const result = await component.execute(query);
 
-    t.ok(result, 'has result');
-    t.ok(result.data, 'data returned');
-    t.error(result.errors, 'no errors');
+    t.deepEqual(result, { book: { title: 'Some Title' } }, 'has result');
   });
 
   t.test('execute error', async (t) => {
@@ -81,11 +77,11 @@ Test('test component execute', (t) => {
 
     const result = await component.execute(query);
 
-    t.ok(result.errors, 'errors');
+    t.ok(result.book instanceof Error, 'error');
   });
 
   t.test('execute multiple query', async (t) => {
-    t.plan(3);
+    t.plan(1);
 
     const query = `
       query {
@@ -101,9 +97,7 @@ Test('test component execute', (t) => {
 
     const result = await component.execute(query);
 
-    t.ok(result, 'has result');
-    t.deepEqual(result.data, { one: { title: 'Some Title' }, two: { id: '2', title: 'Some Title' } }, 'data returned');
-    t.error(result.errors, 'no errors');
+    t.deepEqual(result, { one: { title: 'Some Title' }, two: { id: '2', title: 'Some Title' } }, 'data returned');
   });
 
 });

--- a/test/test-mocks.js
+++ b/test/test-mocks.js
@@ -68,8 +68,9 @@ Test('test component mocks', (t) => {
       }
     `;
     const result = await componentC.execute(query);
-    t.equal(result.data.a.value, 'a', 'returns Component A\'s mock');
-    t.equal(result.data.b.value, 'b', 'returns Component B\'s mock');
-    t.equal(result.data.c.value, 'c', 'returns Component C\'s mock');
+
+    t.equal(result.a.value, 'a', 'returns Component A\'s mock');
+    t.equal(result.b.value, 'b', 'returns Component B\'s mock');
+    t.equal(result.c.value, 'c', 'returns Component C\'s mock');
   });
 });

--- a/test/test-mocks.js
+++ b/test/test-mocks.js
@@ -67,7 +67,7 @@ Test('test component mocks', (t) => {
         c { value }
       }
     `;
-    const result = await componentC.execute(query);
+    const result = await componentC.execute(query, { mergeErrors: true });
 
     t.equal(result.a.value, 'a', 'returns Component A\'s mock');
     t.equal(result.b.value, 'b', 'returns Component B\'s mock');


### PR DESCRIPTION
This change squashes errors into the `data` of a `graphql.execute` call such that if returned from a resolver, mulptiple errors will be added to the response instead of that resolver only being able to throw one error.