### PR TITLE
fix graphql-toolkit peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "debug": "^4.1.0",
     "graphql-extensions": "^0.5.2",
     "graphql-tag": "^2.10.1",
+    "graphql-tag-pluck": "^0.8.7",
     "graphql-toolkit": "^0.5.0",
     "graphql-tools": "^4.0.5"
   },


### PR DESCRIPTION
when installing graphql-component you get: `npm WARN graphql-toolkit@0.5.18 requires a peer of graphql-tag-pluck@^0.8.3 but none is installed. You must install peer dependencies yourself.` Seeing as graphql-component is a direct consumer of graphql-toolkit it makes sense to provide this dependency to quelch this warning