### PR TITLE
Cleanup empty types after exclusion

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -3,14 +3,6 @@
 const { parse } = require('graphql');
 const debug = require('debug')('graphql-component:types');
 
-const iterateObjectTypes = function *(definitions) {
-  for (const definition of definitions) {
-    if (definition.kind === 'ObjectTypeDefinition' && ['Query', 'Mutation', 'Subscription'].indexOf(definition.name.value) > -1) {
-      yield definition;
-    }
-  }
-};
-
 const check = function (operation, fieldName, excludes) {
   return excludes.map(([root, name]) => {
     if (root === '*') {
@@ -26,14 +18,26 @@ const exclude = function (types, excludes) {
   }
 
   for (const doc of types) {
-    for (const def of iterateObjectTypes(doc.definitions)) {
-      def.fields = def.fields.filter((field) => {
-        if (check(def.name.value, field.name.value, excludes)) {
-          debug(`excluding ${def.name.value}.${field.name.value} from import`);
-          return false;
+    const {definitions} = doc;
+    // iterate through the document's definitions and apply exclusions to applicable definitions.
+    // if the definition has no fields after exclusions are applied, remove the definition from the document
+    // we are iterating through the definitions backwards so that when we remove a definition the
+    // inner for loop's index calculation stays in sync
+    for (let i = definitions.length - 1; i >= 0; --i) {
+      const def = definitions[i]
+      if (def.kind === 'ObjectTypeDefinition' && ['Query', 'Mutation', 'Subscription'].indexOf(def.name.value) > -1) {
+        def.fields = def.fields.filter((field) => {
+          if (check(def.name.value, field.name.value, excludes)) {
+            debug(`excluding ${def.name.value}.${field.name.value} from import`);
+            return false;
+          }
+          return true;
+        });
+        // all of the fields of this definition were removed, so remove the definition from the document
+        if (def.fields.length === 0) {
+          definitions.splice(i, 1);
         }
-        return true;
-      });
+      }
     }
   }
 

--- a/test/test-types.js
+++ b/test/test-types.js
@@ -7,7 +7,7 @@ const Types = require('../lib/types');
 
 Test('type utilities', (t) => {
 
-  t.test('get types', (t) => {
+  t.test('get types with no imports', (t) => {
 
     t.plan(2);
 
@@ -27,8 +27,8 @@ Test('type utilities', (t) => {
     const schema = buildASTSchema(types[0]);
 
 
-    t.ok(schema.getType('A').getFields().value, 'the "A" type exists');
-    t.ok(schema.getQueryType().getFields().a, 'the "a" query exists');
+    t.ok(schema.getType('A').getFields().value, `the "A" type exists in component's schema`);
+    t.ok(schema.getQueryType().getFields().a, `the "a" query exists in component's schema`);
   });
 
   t.test('get imported types', (t) => {
@@ -56,12 +56,12 @@ Test('type utilities', (t) => {
 
     const types = Types.getImportedTypes({}, component);
     const schemaA = buildASTSchema(types[0]);
-    t.ok(schemaA.getType('A').getFields().value, 'the "A" type exists');
-    t.ok(schemaA.getQueryType().getFields().a, 'the "a" query exists');
+    t.ok(schemaA.getType('A').getFields().value, `the "A" type exists in component's schema`);
+    t.ok(schemaA.getQueryType().getFields().a, `the "a" query exists in component's schema`);
 
     const schemaB = buildASTSchema(types[1])
-    t.ok(schemaB.getType('B').getFields().value, 'the "B" type exists');
-    t.ok(schemaB.getQueryType().getFields().b, 'the "b" query exists');
+    t.ok(schemaB.getType('B').getFields().value, `the "B" type exists in imported component's schema`);
+    t.ok(schemaB.getQueryType().getFields().b, `the "b" query exists in imported component's schema`);
   });
 
   t.test('exclude', (t) => {
@@ -89,12 +89,12 @@ Test('type utilities', (t) => {
 
     const types = Types.getImportedTypes({}, component, [['Query', 'b']]);
     const schemaA = buildASTSchema(types[0]);
-    t.ok(schemaA.getType('A').getFields().value, 'the "A" type exists');
-    t.ok(schemaA.getQueryType().getFields().a, 'the "a" query exists');
+    t.ok(schemaA.getType('A').getFields().value, `the "A" type exists in component's schema`);
+    t.ok(schemaA.getQueryType().getFields().a, `the "a" query exists in component's schema`);
 
     const schemaB = buildASTSchema(types[1])
-    t.ok(schemaB.getType('B').getFields().value, 'the "B" type exists');
-    t.notOk(schemaB.getQueryType().getFields().b, 'the "b" query does not exist');
+    t.ok(schemaB.getType('B').getFields().value, `the "B" type exists in imported component's schema`);
+    t.notOk(schemaB.getQueryType(), `the "Query" type does not exist in imported component's schema because all of its fields have been removed`);
   });
 
   t.test('exclude caching', (t) => {
@@ -109,24 +109,25 @@ Test('type utilities', (t) => {
         }
         type Query {
           a: A
+          b(c: Int): A
         }
       `]
     };
 
     let types = Types.getImportedTypes({}, component, [['Query', 'a']]);
     let schema = buildASTSchema(types[0]);
-    t.ok(schema.getType('A').getFields().value, 'the "A" type exists');
-    t.notOk(schema.getQueryType().getFields().a, 'the "a" query does not exist');
+    t.ok(schema.getType('A').getFields().value, `the "A" type exists in component's schema`);
+    t.notOk(schema.getQueryType().getFields().a, `the "a" query does not exist in component's schema`);
 
     types = Types.getImportedTypes({}, component);
     schema = buildASTSchema(types[0]);
-    t.ok(schema.getType('A').getFields().value, 'the "A" type exists');
-    t.ok(schema.getQueryType().getFields().a, 'the "a" query exists');
+    t.ok(schema.getType('A').getFields().value, `the "A" type exists in component's schema`);
+    t.ok(schema.getQueryType().getFields().a, `the "a" query exists in component's schema`);
   });
 
   t.test('exclude all', (t) => {
 
-    t.plan(2);
+    t.plan(3);
 
     const component = {
       _importedTypes: [],
@@ -145,11 +146,12 @@ Test('type utilities', (t) => {
 
     const types = Types.getImportedTypes({}, component, [['*']]);
     const schema = buildASTSchema(types[0]);
-    t.notOk(schema.getQueryType().getFields().a, 'the "a" query does not exist');
-    t.notOk(schema.getMutationType().getFields().a, 'the "a" mutation does not exist');
+    t.notOk(schema.getQueryType(), `the "Query" type does not exist in component's schema because all of it's fields were removed`);
+    t.notOk(schema.getMutationType(), `the "Mutation" type does not exist in component's schema because all of its fields were removed`);
+    t.ok(schema.getType('A').getFields().value, `the "A" type and its field exist in component's schema`);
   });
-
-  t.test('exclude one mutation', (t) => {
+  
+  t.test('component with no Mutation and 1 Query with imported component with 2 Mutations and 1 Query, exclude 1 Mutation and 1 Query from imported component', (t) => {
     t.plan(6);
 
     const component = {
@@ -177,13 +179,13 @@ Test('type utilities', (t) => {
 
     const types = Types.getImportedTypes({}, component, [['Mutation', 'b1'], ['Query', 'b']]);
     const schemaA = buildASTSchema(types[0]);
-    t.ok(schemaA.getType('A').getFields().value, 'the "A" type exists');
-    t.ok(schemaA.getQueryType().getFields().a, 'the "a" query exists');
+    t.ok(schemaA.getType('A').getFields().value, `the "A" type exists in component's schema`);
+    t.ok(schemaA.getQueryType().getFields().a, `the "a" query exists in component's schema`);
 
     const schemaB = buildASTSchema(types[1])
-    t.ok(schemaB.getType('B').getFields().value, 'the "B" type exists');
-    t.notOk(schemaB.getQueryType().getFields().b, 'the "b" query does not exist');
-    t.notOk(schemaB.getMutationType().getFields().b1, 'the "b1" mutation does not exist');
-    t.ok(schemaB.getMutationType().getFields().b2, 'the "b2" query exists');
+    t.ok(schemaB.getType('B').getFields().value, `the "B" type exists in imported component's schema`);
+    t.notOk(schemaB.getQueryType(), `the "Query" type does not exist in imported component's schema because all of its fields were removed`);
+    t.notOk(schemaB.getMutationType().getFields().b1, `the "b1" mutation does not exist in imported component's schema`);
+    t.ok(schemaB.getMutationType().getFields().b2, `the "b2" mutation exists in imported component's schema`);
   });
 });


### PR DESCRIPTION
@dmicoud found an issue with exclusions while developing his composition application. Effectively, parent component A imports child component B. Parent component A does not have any `Mutations` while parent component A excludes all Mutations from child component B via `Mutation.*`. In this case, on server start up the following stack trace was occurring:
```
node:26369) UnhandledPromiseRejectionWarning: Error: Type Mutation must define one or more fields.
    at assertValidSchema (/Users/<redacted>/node_modules/graphql/type/validate.js:71:11)
    at assertValidExecutionArguments (/Users/<redacted>/node_modules/graphql/execution/execute.js:136:35)
    at executeImpl (/Users/<redacted>/node_modules/graphql/execution/execute.js:86:3)
    at Object.execute (/Users/<redacted>/node_modules/graphql/execution/execute.js:64:63)
    at Object.generateSchemaHash (/Users/<redacted>/node_modules/apollo-server-core/dist/utils/schemaHash.js:14:32)
    at ApolloServer.generateSchemaDerivedData (/Users/<redacted>/node_modules/apollo-server-core/dist/ApolloServer.js:285:41)
    at new ApolloServerBase (/Users/<redacted>/node_modules/apollo-server-core/dist/ApolloServer.js:204:38)
    at new ApolloServer (/Users/<redacted>/node_modules/apollo-server-hapi/dist/ApolloServer.js:29:1)
    at Object.register (/Users/<redacted>/node_modules/@expediagroup/hapi-graphql-bootstrap/lib/index.js:90:26)
    at internals.Server.register (/Users/<redacted>/node_modules/hapi/lib/server.js:451:35)
```
This is because the parent component does not have a Mutation type, and all fields from the child component's Mutation type were excluded.

This PR modifies the exclusion loop to remove a `Query`, `Mutation`, or `Subscription` definition from the AST if all of its fields are excluded. 