### PR TITLE
remove default value for context arg in execute()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Unreleased
+
+- Remove `this._context` as default value for context in `execute()` requiring `execute()` users to pass in context from a calling resolver.
 
 ### v1.2.4
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -107,7 +107,7 @@ class GraphQLComponent {
     return check && check._types && check._resolvers && check._imports;
   }
 
-  async execute(input, { mergeErrors = false, root = undefined, context = this._context, variables = {} } = {}) {
+  async execute(input, { mergeErrors = false, root = undefined, context = {}, variables = {} } = {}) {
     const document = typeof input === 'string' ? gql`${this._fragments.join('\n')}\n${input}` : input;
     
     const { data = {}, errors = [] } = await graphql.execute({ document, schema: this.schema, rootValue: root, contextValue: context, variableValues: variables });


### PR DESCRIPTION
We didn't provide unit testing for this and I tested it out and it doesn't work. I don't think providing the context by default for execute will ever work in this fashion (unless we cache the result when Apollo calls [this function](https://github.com/ExpediaGroup/graphql-component/blob/master/lib/context.js#L32)) since you need Apollo Server to pass in the incoming request object by calling the context function that we expose.