### PR TITLE
modify wrapResolvers to properly handle Subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,9 @@
 ### Unreleased
 
 - Resolver `memoize` key includes the `info.path.key` to keep different aliases from colliding
-
-### v1.3.0 
-
 - Imported resolvers will delegate to the imported component schema to which they belong.
 - Remove `this._context` as default value for context in `execute()` requiring `execute()` users to pass in context from a calling resolver.
+- Remove binding of `GraphQLComponent` class context to Subscription resolvers.
 
 ### v1.2.4
 

--- a/lib/resolvers.js
+++ b/lib/resolvers.js
@@ -63,6 +63,7 @@ const wrapResolvers = function (bind, resolvers = {}) {
       wrapped[name] = value;
       continue;
     }
+
     if (!wrapped[name]) {
       wrapped[name] = {};
     }
@@ -71,21 +72,19 @@ const wrapResolvers = function (bind, resolvers = {}) {
       if (wrapped[name][resolverName]) {
         continue;
       }
-      if (['Query', 'Mutation', 'Subscription'].indexOf(name) > -1) {
+
+      if (['Query', 'Mutation'].indexOf(name) > -1) {
         debug(`memoized ${name}.${resolverName}`);
         wrapped[name][resolverName] = memoize(name, resolverName, func.bind(bind));
-        continue;
+      } else {
+        // conditionally bind func since func will not be a function for
+        // Subscriptions and internal enum remapping
+        wrapped[name][resolverName] = typeof func === 'function' ? func.bind(bind) : func;
       }
-      // bind if the value mapped to a resolverName is a function
-      // otherwise dont to support internal enum value remapping
-      wrapped[name][resolverName] = typeof func === 'function' ? func.bind(bind) : func;
     }
-
   }
-
   return wrapped;
 };
-
 const createProxyResolver = function (component, root, field) {
   const proxyResolver = function (_, args, context, info) {
     debug(`delegating ${root}.${field} to imported component schema.`);

--- a/test/test-resolvers.js
+++ b/test/test-resolvers.js
@@ -1,12 +1,18 @@
 'use strict';
 
 const Test = require('tape');
-const { Kind } = require('graphql');
-const { memoize, transformResolvers, wrapResolvers, getImportedResolvers, createProxyResolvers, createProxyResolver, createOperationForField } = require('../lib/resolvers');
+const {
+  memoize,
+  transformResolvers,
+  wrapResolvers,
+  getImportedResolvers,
+  createProxyResolvers,
+  createProxyResolver 
+} = require('../lib/resolvers');
 
 Test('wrapping', (t) => {
 
-  t.test('wrap resolver function', (t) => {
+  t.test('wrap Query resolver function', (t) => {
 
     t.plan(1);
 
@@ -22,7 +28,41 @@ Test('wrapping', (t) => {
 
     const value = wrapped.Query.test({}, {}, {}, { parentType: 'Query', path: { key: 'test' } });
 
-    t.equal(value, 1, 'resolver was bound');
+    t.equal(value, 1, 'Query resolver was bound');
+  });
+
+  t.test('wrap Mutation resolver function', (t) => {
+
+    t.plan(1);
+
+    const resolvers = {
+      Mutation: {
+        test() {
+          return this.id;
+        }
+      }
+    };
+
+    const wrapped = wrapResolvers({ id: 1 }, resolvers);
+    const value = wrapped.Mutation.test({}, {}, {}, { parentType: 'Mutation', path: { key: 'test' } });
+
+    t.equal(value, 1, 'Mutation resolver was bound');
+  });
+
+  t.test('wrap Subscription resolver object', (t) => {
+    t.plan(1);
+
+    const resolvers = {
+      Subscription: {
+        someSub: {
+          subscribe: () => { t.equal(this.id, undefined, 'subscription subscribe() resolver was not bound to the wrapResolvers input object containing an id field')}
+        }
+      }
+    };
+
+    const wrapped = wrapResolvers({ id: 1 }, resolvers);
+    // call the wrapped resolver result to assert this test case
+    wrapped.Subscription.someSub.subscribe();
   });
 
   t.test('wrap resolver mapped to primitive (enum remap)', (t) => {


### PR DESCRIPTION
this change was very similar to the modification made to `wrapResolvers` to handle a resolver map that contains an internal enum remapping. A subscription resolver map declaration looks like this:

```javascript
const resolvers = {
  Subscription: {
    postAdded: {
      subscribe: () => { ... },
      // optionally
      resolve: (payload) => { ... }
    }
  }
}
```
which meant that we were trying to bind `postAdded` which is an object and not a function. 

