### PR TITLE
proxyImportedResolvers option to include exclude scenario

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -81,7 +81,7 @@ class GraphQLComponent {
 
         importedDirectives.push(getImportedDirectives(this, component));
         importedTypes.push(...getImportedTypes(this, component, excludes));
-        importedResolvers.push(transformResolvers(getImportedResolvers(component), excludes));
+        importedResolvers.push(transformResolvers(getImportedResolvers(component, proxyImportedResolvers), excludes));
       }
 
       this._imports.push(component);

--- a/test/test-resolvers.js
+++ b/test/test-resolvers.js
@@ -224,6 +224,69 @@ Test('transform', (t) => {
 
 });
 
+Test('transform and proxyImportedResolvers=true', (t) => {
+
+  t.test('exclude wildcard', (t) => {
+    t.plan(2);
+
+    const imp = {
+      _resolvers: {
+        Query: {
+          test() {
+            return true;
+          }
+        }
+      },
+      _importedResolvers: {
+        Query: {
+          imported() {
+            return true;
+          }
+        }
+      }
+    };
+
+    const imported = getImportedResolvers(imp, true);
+
+    const transformed = transformResolvers(imported, [['Mutation', '*']]);
+    t.ok(transformed.Query.test.__isProxy, 'resolver is proxy');
+    t.ok(transformed.Query.imported.__isProxy, 'transitive resolver is proxy');
+
+  });
+
+});
+
+Test('transform and proxyImportedResolvers=false', (t) => {
+
+  t.test('exclude wildcard', (t) => {
+    t.plan(1);
+
+    const imp = {
+      _resolvers: {
+        Query: {
+          test() {
+            return true;
+          }
+        }
+      },
+      _importedResolvers: {
+        Query: {
+          imported() {
+            return true;
+          }
+        }
+      }
+    };
+
+    const imported = getImportedResolvers(imp, false);
+
+    const transformed = transformResolvers(imported, [['Mutation', '*']]);
+    t.ok(!transformed.Query.test.__isProxy, 'resolver is not proxy');
+
+  });
+
+});
+
 Test('proxy resolvers', (t) => {
 
   t.test('get imported resolvers with proxy flag true', (t) => {

--- a/test/test-resolvers.js
+++ b/test/test-resolvers.js
@@ -227,7 +227,7 @@ Test('transform', (t) => {
 Test('transform and proxyImportedResolvers=true', (t) => {
 
   t.test('exclude wildcard', (t) => {
-    t.plan(2);
+    t.plan(4);
 
     const imp = {
       _resolvers: {
@@ -251,6 +251,8 @@ Test('transform and proxyImportedResolvers=true', (t) => {
     const transformed = transformResolvers(imported, [['Mutation', '*']]);
     t.ok(transformed.Query.test.__isProxy, 'resolver is proxy');
     t.ok(transformed.Query.imported.__isProxy, 'transitive resolver is proxy');
+    t.ok(transformed.Query && transformed.Query.test, 'query present');
+    t.ok(!transformed.Mutation, 'mutation not present');
 
   });
 
@@ -259,7 +261,7 @@ Test('transform and proxyImportedResolvers=true', (t) => {
 Test('transform and proxyImportedResolvers=false', (t) => {
 
   t.test('exclude wildcard', (t) => {
-    t.plan(1);
+    t.plan(3);
 
     const imp = {
       _resolvers: {
@@ -282,6 +284,8 @@ Test('transform and proxyImportedResolvers=false', (t) => {
 
     const transformed = transformResolvers(imported, [['Mutation', '*']]);
     t.ok(!transformed.Query.test.__isProxy, 'resolver is not proxy');
+    t.ok(transformed.Query && transformed.Query.test, 'query present');
+    t.ok(!transformed.Mutation, 'mutation not present');
 
   });
 


### PR DESCRIPTION
Currently, the proxyImportedResolvers flag gets passed only if there is no `exclude` which prevents wrapping imported resolvers in proxy when root types are being excluded on the imported component. This causes non-root type resolvers getting executed twice. This change will allow to pass-down proxyImportedResolvers option to include exclude scenarios also, which will prevent non-root type resolvers execution more than once.

I thought of adding a unit test for this specific change, but for that, we need to revamp the component Unit test and there are already Unit tests for the `getImportedResolvers` function. 
However, I verified this change by pulling this change within a composed component and verified that the non-root type resolver gets executed only once.  