### PR TITLE
bug fix - TypeError: Cannot convert undefined or null to object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -69,7 +69,7 @@ class GraphQLComponent {
 
       const { component, exclude, proxyImportedResolvers = true } = imp;
 
-      const excludes = !exclude || !exclude.length ? [] : exclude.filter((filter) => {
+      const excludes = !exclude || !exclude.length ? [] : exclude.map((filter) => {
         return filter.split('.');
       });
 


### PR DESCRIPTION
The `exclude.filter` is causing runtime error for the composed components when there are root type exclusions. Changing this to `exclude.map` will fix that issue.