### PR TITLE
1.x backport abstract type fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To intercept resolvers with mocks execute this app with `GRAPHQL_MOCK=1` enabled
   - `context` - an optional object { namespace, factory } for contributing to context.
   - `directives` - an optional object containing custom schema directives.
   - `useMocks` - enable mocks.
-  - `preserveMockResolvers` - preserve type resolvers in mock mode.
+  - `preserveResolvers` - preserve type resolvers in mock mode.
   - `mocks` - an optional object containing mock types.
   - `dataSources` - an array of data sources instances to make available on `context.dataSources` .
   - `dataSourceOverrides` - overrides for data sources in the component tree.
@@ -111,7 +111,6 @@ Imports can be a configuration object supplying the following properties:
 
 - `component` - the component instance to import.
 - `exclude` - fields, if any, to exclude.
-- `proxyImportedResolvers` - enable/disable wrapping imported resolvers in a proxy (defaults to `true`).
 
 ### Exclude
 
@@ -133,14 +132,6 @@ const { schema, context } = new GraphQLComponent({
 ```
 
 This will keep from leaking unintended surface area. But you can still delegate calls to the component's schema to enable it from the API you do expose.
-
-### proxyImportedResolvers
-
-When importing a component's resolvers, the default behavior is to replace the resolver with a function that executes a graphql query against the imported component for that field.
-
-This allows components to compose together without accidentally potentially re-running type resolvers.
-
-To disable this functionality (if you are never calling a sub-component's `execute` function), set to `false`.
 
 ### Data Source support
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@ const gql = require('graphql-tag');
 const { buildFederatedSchema } = require('@apollo/federation');
 const { makeExecutableSchema, addMockFunctionsToSchema, SchemaDirectiveVisitor } = require('graphql-tools');
 const { mergeResolvers, mergeTypeDefs } = require('graphql-toolkit');
-const { getImportedResolvers, transformResolvers, wrapResolvers } = require('./resolvers');
+const { getImportedResolvers, wrapResolvers } = require('./resolvers');
 const { wrapContext, createContext } = require('./context');
 const { getImportedTypes } = require('./types');
 const { buildFragments } = require('./fragments');
@@ -58,24 +58,21 @@ class GraphQLComponent {
     const importedDirectives = [];
 
     for (const imp of imports) {
+      let component;
+      let exclude;
+
       if (GraphQLComponent.isComponent(imp)) {
-        const component = imp;
-        importedDirectives.push(getImportedDirectives(this, component));
-        importedTypes.push(...getImportedTypes(this, component));
-        importedResolvers.push(getImportedResolvers(component, true));
-        this._imports.push(component);
-        continue;
+        component = imp;
+      } else {
+        // if its not a component, assume it's a component config object
+        // { component: <component instance>, exclude: [...]}
+        component = imp.component;
+        exclude = imp.exclude;
       }
 
-      const { component, exclude, proxyImportedResolvers = true } = imp;
-
-      const excludes = !exclude || !exclude.length ? [] : exclude.map((filter) => {
-        return filter.split('.');
-      });
-
       importedDirectives.push(getImportedDirectives(this, component));
-      importedTypes.push(...getImportedTypes(this, component, excludes));
-      importedResolvers.push(transformResolvers(getImportedResolvers(component, proxyImportedResolvers), excludes));
+      importedTypes.push(...getImportedTypes(this, component, exclude));
+      importedResolvers.push(getImportedResolvers(component, exclude));
 
       this._imports.push(component);
     }

--- a/lib/resolvers.js
+++ b/lib/resolvers.js
@@ -144,17 +144,6 @@ const createSubOperationForField = function (component, fieldPath, info) {
 
   const selections = getSelectionSetForPath([...fieldPath], operation.selectionSet);
 
-  //Add __typename request for usage in __resolveType
-  if (selections && selections.selectionSet) {
-    selections.selectionSet.selections.push({
-      kind: Kind.FIELD,
-      name: {
-        kind: Kind.NAME,
-        value: '__typename'
-      }
-    });
-  }
-
   definitions.push({
     kind: Kind.OPERATION_DEFINITION,
     operation: operation.operation,
@@ -268,15 +257,10 @@ const getImportedResolvers = function (component, exclusions) {
     } else {
       for (const [field, resolver] of Object.entries(fieldResolvers)) {
         if (field.startsWith('__')) {
-          resultingResolverMap[type] = {};
-          if (field === '__resolveType') {
-            // the child has a __resolveType - at the parent level replace it with a function that returns the parent resolver result's __typename
-            resultingResolverMap[type][field] = function (_) {
-              return _.__typename;
-            }
-          } else {
-            resultingResolverMap[type][field] = resolver;
+          if (resultingResolverMap[type] === undefined) {
+            resultingResolverMap[type] = {};
           }
+          resultingResolverMap[type][field] = resolver;
         }
       }
     }

--- a/lib/resolvers.js
+++ b/lib/resolvers.js
@@ -50,42 +50,6 @@ const memoize = function (parentType, fieldName, resolve) {
 };
 
 /**
- * excludes types and/or fields on types from an input resolver map
- * @param {Object} resolvers - the resolver map to be transformed
- * @param {Array<string>} excludes - an array of exclusions in the general form 
- * of "type.field". This format supports excluding all types ('*'), an entire 
- * type and the fields it encloses ('type', 'type.', 'type.*'), and individual 
- * fields on a type ('type.somefield').
- * @returns {Object} - a new resolver map with the applied exclusions
- */
-const transformResolvers = function (resolvers, excludes) {
-  if (!excludes || excludes.length < 1) {
-    return resolvers;
-  }
-
-  let filteredResolvers = Object.assign({}, resolvers);
-
-  for (const [type, field] of excludes) {
-    if (type === '*') {
-      filteredResolvers = {};
-      break;
-    }
-    if (!field || field === '' || field === '*') {
-      delete filteredResolvers[type];
-      continue;
-    }
-    delete filteredResolvers[type][field];
-    // covers the case where all fields of a type were specified 1 by 1, which
-    // should result in the entire type being removed
-    if (Object.keys(filteredResolvers[type]).length === 0) {
-      delete filteredResolvers[type];
-    }
-  }
-
-  return filteredResolvers;
-};
-
-/**
  * binds an object context to resolver functions in the input resolver map
  * @param {Object} bind - the object context to bind to resolver functions
  * @param {Object} resolvers - the resolver map containing the resolver 
@@ -180,6 +144,17 @@ const createSubOperationForField = function (component, fieldPath, info) {
 
   const selections = getSelectionSetForPath([...fieldPath], operation.selectionSet);
 
+  //Add __typename request for usage in __resolveType
+  if (selections && selections.selectionSet) {
+    selections.selectionSet.selections.push({
+      kind: Kind.FIELD,
+      name: {
+        kind: Kind.NAME,
+        value: '__typename'
+      }
+    });
+  }
+
   definitions.push({
     kind: Kind.OPERATION_DEFINITION,
     operation: operation.operation,
@@ -253,52 +228,60 @@ const createProxyResolver = function (component, rootType, fieldName) {
 };
 
 /**
- * replace the input component's root type field resolvers with a proxy
- * @param {Object} component - the component's whose root type field resolvers 
- * will be replaced with a proxy 
- * @param {Object} resolvers - the combined resolver map for the input component
- * @returns {Object} - the resolver map with root type field resolvers replaced
- * with a proxy function
+ * imports a component's resolvers by combining the component's own/imported 
+ * resolvers (with exclusions), replacing root type resolvers with a proxy and 
+ * pulling up abstract non-root type resolver functions
+ * @param {Object} component - the imported component whose resolvers will be 
+ * imported
+ * @param {Array<String>} exclusions - an array of exclusion strings in the 
+ * form of 'Type.field' resulting in resolvers for each Type.field being 
+ * excluded
+ * @returns {Object} - a resolver map representing the imported resolvers for 
+ * the input component
  */
-const createProxyResolvers = function (component, resolvers) {
-  const proxyResolvers = {};
+const getImportedResolvers = function (component, exclusions) {
 
-  const iterateRootTypeResolvers = function* () {
+  // merge the components own and imported resolvers into a single resolver map
+  const resolvers = Object.assign({}, mergeResolvers([component._resolvers, component._importedResolvers], { exclusions }));
+
+  const resultingResolverMap = {};
+
+  const iterateResolvers = function* () {
     for (const type of Object.keys(resolvers)) {
-      if (['Query', 'Mutation', 'Subscription'].indexOf(type) > -1) {
-        yield [type, resolvers[type]];
-      }
+      yield [type, resolvers[type]]
     }
   };
 
-  for (const [rootType, fieldResolvers] of iterateRootTypeResolvers()) {
-    if (proxyResolvers[rootType] === undefined) {
-      proxyResolvers[rootType] = {};
-    }
-    for (const [field, resolver] of Object.entries(fieldResolvers)) {
-      if (resolver.__isProxy === true) {
-        proxyResolvers[rootType][field] = resolver;
-        continue;
+  for (const [type, fieldResolvers] of iterateResolvers()) {
+    if (['Query', 'Mutation', 'Subscription'].indexOf(type) > -1) {
+      if (resultingResolverMap[type] === undefined) {
+        resultingResolverMap[type] = {};
       }
-      proxyResolvers[rootType][field] = createProxyResolver(component, rootType, field);
+
+      for (const [field, resolver] of Object.entries(fieldResolvers)) {
+        if (resolver.__isProxy == true) {
+          continue;
+        }
+
+        resultingResolverMap[type][field] = createProxyResolver(component, type, field);
+      }
+    } else {
+      for (const [field, resolver] of Object.entries(fieldResolvers)) {
+        if (field.startsWith('__')) {
+          resultingResolverMap[type] = {};
+          if (field === '__resolveType') {
+            // the child has a __resolveType - at the parent level replace it with a function that returns the parent resolver result's __typename
+            resultingResolverMap[type][field] = function (_) {
+              return _.__typename;
+            }
+          } else {
+            resultingResolverMap[type][field] = resolver;
+          }
+        }
+      }
     }
   }
-
-  return proxyResolvers;
+  return resultingResolverMap;
 };
 
-/**
- * combine a component's own resolvers with its imported resolvers
- * @param {Object} component - the component whose own resolvers and imported r
- * esolvers will be combined into 1 resolver map
- * @param {Boolean} proxyImportedResolvers - whether or not to replace the 
- * input component's root type field resolvers with a proxy
- * @returns {Object} - the combined resolver map
- */
-const getImportedResolvers = function (component, proxyImportedResolvers) {
-  const mergedResolvers = Object.assign({}, mergeResolvers([component._resolvers, component._importedResolvers]));
-
-  return proxyImportedResolvers === true ? createProxyResolvers(component, mergedResolvers) : mergedResolvers;
-};
-
-module.exports = { memoize, transformResolvers, wrapResolvers, getImportedResolvers, createProxyResolvers, createProxyResolver, delegateToComponent };
+module.exports = { memoize, wrapResolvers, getImportedResolvers, createProxyResolver, delegateToComponent };

--- a/lib/types.js
+++ b/lib/types.js
@@ -12,7 +12,7 @@ const check = function (operation, fieldName, excludes) {
   }).some(check => check);
 };
 
-const exclude = function (types, excludes) {
+const excludeTypes = function (types, excludes) {
   if (!excludes || excludes.length < 1) {
     return types;
   }
@@ -70,10 +70,13 @@ const namespaceDirectives = function (directives, id, document) {
   return document;
 };
 
-const getImportedTypes = function (parent, component, excludes) {
+const getImportedTypes = function (parent, component, exclude) {
+  const excludes = !exclude || !exclude.length ? [] : exclude.map((filter) => {
+    return filter.split('.');
+  }); 
   const types = component._types.map((type) => namespaceDirectives(parent._directives || {}, component._id, parse(type)));
   const importedTypes = component._importedTypes;
-  return exclude([...types, ...importedTypes], excludes);
+  return excludeTypes([...types, ...importedTypes], excludes);
 };
 
-module.exports = { exclude, check, getImportedTypes };
+module.exports = { excludeTypes, check, getImportedTypes };

--- a/test/test-delegate.js
+++ b/test/test-delegate.js
@@ -3,7 +3,7 @@
 const Test = require('tape');
 const GraphQLComponent = require('../lib');
 
-Test('component resolver delegate', async (t) => {
+Test(`parent pulls up and delegates to child's query`, async (t) => {
 
   t.plan(1);
 
@@ -36,7 +36,7 @@ Test('component resolver delegate', async (t) => {
   t.equal(test.value, true, 'resolved');
 });
 
-Test('component resolver delegate errors', async (t) => {
+Test('parent pulls up and delegates to child query that throws error', async (t) => {
 
   t.plan(2);
 
@@ -75,6 +75,126 @@ Test('component resolver delegate errors', async (t) => {
 
   const { test } = await component.execute(`query { test { ...AllTest } }`, { mergeErrors: true });
   
-  t.equal(test.value, true, 'resolved');
-  t.ok(test.err instanceof Error, 'got error');
+  t.equal(test.value, true, 'field `value` resolved as expected');
+  t.ok(test.err instanceof Error, 'field `error` resolved as error');
 });
+
+Test(`parent delegates to child's query that returns an abstract type`, async (t) => {
+  let childResolveTypeCallCount = 0;
+  const child = new GraphQLComponent({
+    types: `
+      type Query {
+        inventory: [Item]
+      }
+
+      interface Item {
+        id: ID
+      }
+
+      type Book implements Item {
+        id: ID
+        title: String
+      }
+
+      type Laptop implements Item {
+        id: ID
+        brand: String
+      }
+    `,
+    resolvers: {
+      Query: {
+        inventory() {
+          return [
+            {
+              id: 1,
+              title: 'Some book title'
+            },
+            {
+              id: 2,
+              brand: 'Apple'
+            }
+          ];
+        }
+      },
+      Item: {
+        __resolveType(item) {
+          childResolveTypeCallCount = childResolveTypeCallCount + 1;
+          if (item.title) {
+            return 'Book'
+          } else if (item.brand) {
+            return 'Laptop'
+          }
+        }
+      }
+    }
+  })
+  const parent = new GraphQLComponent({
+    imports: [
+      child
+    ]
+  });
+
+  const result = await parent.execute(`query { inventory { id, ... on Book { title }, ... on Laptop { brand } } }`);
+  t.ok(parent._importedResolvers.Query.inventory.__isProxy, `parent's query resolver is a proxy`);
+  t.equals(childResolveTypeCallCount, 2, `child's resolveType function only called 2 times (1 per result item)`);
+  t.deepEquals(result.data.inventory, [
+    {
+      id: '1',
+      title: 'Some book title',
+      __typename: 'Book'
+    },
+    {
+      id: '2',
+      brand: 'Apple',
+      __typename: 'Laptop'
+    }
+  ], 'query resolved as expected');
+  t.equals(result.errors.length, 0, 'no errors');
+
+  t.end();
+});
+
+Test('parent delegates to child that results in non-root type resolver execution in child', async (t) => {
+  let childNonRootResolverCount = 0;
+  const child = new GraphQLComponent({
+    types: `
+      type Query {
+        child: Child
+      }
+
+      type Child {
+        childField1: String
+        childField2: String
+      }
+    `,
+    resolvers: {
+      Query: {
+        child() {
+          return { childField1: 'childField1' };
+        }
+      },
+      Child: {
+        childField2: function (parent) {
+          childNonRootResolverCount = childNonRootResolverCount + 1;
+          if (parent.childField1) {
+            return `${parent.childField1}-modified`;
+          } else {
+            return 'childField2'
+          }
+        }
+      }
+    }
+  })
+  const parent = new GraphQLComponent({
+    imports: [
+      child
+    ]
+  });
+
+  const result = await parent.execute(`query { child { childField1 childField2 }}`);
+  t.ok(parent._importedResolvers.Query.child.__isProxy, `parent's query resolver is a proxy`);
+  t.equals(childNonRootResolverCount, 1, `child's non root type resolver only called 1 time`);
+  t.deepEquals(result.data.child, { childField1: 'childField1', childField2: 'childField1-modified', __typename: 'Child'});
+  t.equals(result.errors.length, 0, 'no errors');
+  t.end();
+})

--- a/test/test-delegate.js
+++ b/test/test-delegate.js
@@ -80,7 +80,6 @@ Test('parent pulls up and delegates to child query that throws error', async (t)
 });
 
 Test(`parent delegates to child's query that returns an abstract type`, async (t) => {
-  let childResolveTypeCallCount = 0;
   const child = new GraphQLComponent({
     types: `
       type Query {
@@ -118,7 +117,6 @@ Test(`parent delegates to child's query that returns an abstract type`, async (t
       },
       Item: {
         __resolveType(item) {
-          childResolveTypeCallCount = childResolveTypeCallCount + 1;
           if (item.title) {
             return 'Book'
           } else if (item.brand) {
@@ -136,17 +134,14 @@ Test(`parent delegates to child's query that returns an abstract type`, async (t
 
   const result = await parent.execute(`query { inventory { id, ... on Book { title }, ... on Laptop { brand } } }`);
   t.ok(parent._importedResolvers.Query.inventory.__isProxy, `parent's query resolver is a proxy`);
-  t.equals(childResolveTypeCallCount, 2, `child's resolveType function only called 2 times (1 per result item)`);
   t.deepEquals(result.data.inventory, [
     {
       id: '1',
-      title: 'Some book title',
-      __typename: 'Book'
+      title: 'Some book title'
     },
     {
       id: '2',
-      brand: 'Apple',
-      __typename: 'Laptop'
+      brand: 'Apple'
     }
   ], 'query resolved as expected');
   t.equals(result.errors.length, 0, 'no errors');
@@ -194,7 +189,7 @@ Test('parent delegates to child that results in non-root type resolver execution
   const result = await parent.execute(`query { child { childField1 childField2 }}`);
   t.ok(parent._importedResolvers.Query.child.__isProxy, `parent's query resolver is a proxy`);
   t.equals(childNonRootResolverCount, 1, `child's non root type resolver only called 1 time`);
-  t.deepEquals(result.data.child, { childField1: 'childField1', childField2: 'childField1-modified', __typename: 'Child'});
+  t.deepEquals(result.data.child, { childField1: 'childField1', childField2: 'childField1-modified' });
   t.equals(result.errors.length, 0, 'no errors');
   t.end();
 })

--- a/test/test-resolvers.js
+++ b/test/test-resolvers.js
@@ -4,12 +4,11 @@ const Test = require('tape');
 const { GraphQLScalarType } = require('graphql');
 const {
   memoize,
-  transformResolvers,
   wrapResolvers,
   getImportedResolvers,
   createProxyResolver,
-  createProxyResolvers,
 } = require('../lib/resolvers');
+const GraphQLComponent = require('../lib');
 
 Test('memoize()', (t) => {
   t.test('memoize() a resolver function', (st) => {
@@ -118,133 +117,6 @@ Test('memoize()', (t) => {
   });
 });
 
-Test('transformResolvers()', (t) => {
-  t.test('exclusions argument is undefined', (st) => {
-    const resolvers = {
-      Query: {
-        foo() { }
-      }
-    }
-    const transformedResolvers = transformResolvers(resolvers);
-    st.equal(transformedResolvers, resolvers, 'object reference returned from transformResolvers is equal to input reference');
-    st.deepEqual(transformedResolvers, resolvers, 'object content returned from transformResolver is equal to input resolver object content');
-    st.end();
-  });
-
-  t.test('exclusions argument is an empty array', (st) => {
-    const resolvers = {
-      Query: {
-        foo() { }
-      }
-    }
-    const transformedResolvers = transformResolvers(resolvers, []);
-    st.equal(transformedResolvers, resolvers, 'object reference returned from transformResolvers is equal to input reference');
-    st.deepEqual(transformedResolvers, resolvers, 'object content returned from transformResolver is equal to input resolver object content');
-    st.end();
-  });
-
-  t.test(`exclude all types via '*'`, (st) => {
-    const resolvers = {
-      Query: {
-        foo() {}
-      },
-      Mutation: {
-        baz() {}
-      },
-      SomeType: {
-        bar() {}
-      }
-    };
-
-    const transformedResolvers = transformResolvers(resolvers, [['*']]);
-    st.deepEqual(transformedResolvers, {}, 'results in an empty resolver map being returned');
-    st.end();
-  });
-
-  t.test(`exclude a entire type by specifying 'Type' exclusion)`, (st) => {
-    const resolvers = {
-      Query: {
-        foo() {}
-      },
-      SomeType: {
-        bar() {}
-      }
-    };
-
-    const transformedResolvers = transformResolvers(resolvers, [['SomeType']]);
-    st.notOk(transformedResolvers.SomeType, 'entire specified type is excluded');
-    st.ok(transformedResolvers.Query.foo, 'other non-excluded type remains');
-    st.end();
-  });
-
-  t.test(`exclude an entire type by specifying 'Type.' exclusion`, (st) => {
-    const resolvers = {
-      Query: {
-        foo() {}
-      },
-      SomeType: {
-        bar() {}
-      }
-    };
-
-    const transformedResolvers = transformResolvers(resolvers, [['SomeType', '']]);
-    st.notOk(transformedResolvers.SomeType,'entire specified type is excluded');
-    st.ok(transformedResolvers.Query.foo, 'other non-excluded type remains');
-    st.end();
-  });
-
-  t.test(`exclude an entire type by specifying 'Type.*' exclusion`, (st) => {
-    const resolvers = {
-      Query: {
-        foo() {}
-      },
-      SomeType: {
-        bar() {}
-      }
-    };
-
-    const transformedResolvers = transformResolvers(resolvers, [['SomeType', '*']]);
-    st.notOk(transformedResolvers.SomeType, 'entire specified type is excluded');
-    st.ok(transformedResolvers.Query.foo, 'other non-excluded type remains');
-    st.end();
-  });
-
-  t.test(`exclude an individual field on a type`, (st) => {
-    const resolvers = {
-      Query: {
-        foo() {}
-      },
-      SomeType: {
-        bar() {},
-        a() {}
-      }
-    };
-
-    const transformedResolvers = transformResolvers(resolvers, [['SomeType', 'bar']]);
-    st.notOk(transformedResolvers.SomeType.bar, 'specified field on specified type is removed');
-    st.ok(transformedResolvers.SomeType.a, 'non-excluded field on specified type remains');
-    st.ok(transformedResolvers.Query.foo, 'non-exluded type remains');
-    st.end();
-  });
-
-  t.test('exclude all fields on a type via 1 by 1 exclusion', (st) => {
-    const resolvers = {
-      Query: {
-        foo() {}
-      },
-      SomeType: {
-        bar() {},
-        a() {}
-      }
-    };
-
-    const transformedResolvers = transformResolvers(resolvers, [['SomeType', 'bar'], ['SomeType', 'a']]);
-    st.notOk(transformedResolvers.SomeType, 'specified type is completely removed because all of its fields were removed');
-    st.ok(transformedResolvers.Query.foo, 'non-exluded type remains');
-    st.end();
-  })
-});
-
 Test('wrapResolvers()', (t) => {
   t.test('wrap Query field resolver function', (st) => {
     const resolvers = {
@@ -347,87 +219,111 @@ Test('wrapResolvers()', (t) => {
 });
 
 Test('getImportedResolvers()', (t) => {
-  t.test('import resolvers - proxy false', (st) => {
-    // create an object that has the fields that a GraphQLComponent instance would have
-    const importedComponentWhoHasImports = {
-      _resolvers: {
-        Query: {
-          test() {
-            return true;
-          }
+  t.test(`import component's resolvers`, (st) => {
+    const component = new GraphQLComponent({
+      types: `
+        type Query {
+          someQuery: SomeType
         }
-      },
-      _importedResolvers: {
+
+        type SomeType {
+          someField: String
+        }
+      `,
+      resolvers: {
         Query: {
-          transitive() {
-            return true;
+          someQuery() {
+            return { someField: 'hello' }
           }
         }
       }
-    };
+    });
 
-    // imagine the closure this test creates is a parent component calling getImportedResolvers() on an imported component passed through its constructor
-    // _resolvers above would be the imported component's own resolvers
-    // _importedResolvers above would be the imported component's imported resolvers
-    const resolvers = getImportedResolvers(importedComponentWhoHasImports, false);
-
-    st.ok(resolvers.Query.test(), `imported component's own resolver is present`);
-    st.notOk(resolvers.Query.test.__isProxy, `imported component's own resolver is not a proxy`)
-    st.ok(resolvers.Query.transitive(), `imported component's imported resolver (transitive resolver) is present`);
-    st.notOk(resolvers.Query.transitive.__isProxy, `imported component's imported resolver (transitive resolver) is not a proxy`);
+    const importedResolvers = getImportedResolvers(component);
+    st.ok(importedResolvers.Query.someQuery.__isProxy, 'Query.someQuery is a proxy');
+    st.notOk(importedResolvers.SomeType, 'non-root type (SomeType) is not imported')
     st.end();
   });
 
-  t.test('import resolvers - proxy true', (st) => {
-    const importedComponentWhoHasImports = {
-      _resolvers: {
-        Query: {
-          test() {
-            return true;
-          }
+  t.test(`import component's resolvers with exclusion`, (st) => {
+    const component = new GraphQLComponent({
+      types: `
+        type Query {
+          someQuery: SomeType
+          someOtherQuery: String
         }
-      },
-      _importedResolvers: {
+
+        type SomeType {
+          someField: String
+        }
+      `,
+      resolvers: {
         Query: {
-          transitive() {
-            return true;
+          someQuery() {
+            return { someField: 'hello' }
+          },
+          someOtherQuery() {
+            return 'hello';
           }
         }
       }
-    };
-    // imagine the closure this test creates is a parent component calling getImportedResolvers() on an imported component passed through its constructor
-    // _resolvers above would be the imported component's own resolvers
-    // _importedResolvers above would be the imported component's imported resolvers
-    const resolvers = getImportedResolvers(importedComponentWhoHasImports, true);
-    st.ok(resolvers.Query.test, `imported component's own resolver is present`);
-    st.ok(resolvers.Query.test.__isProxy, `imported component's own resolver is not a proxy`)
-    st.ok(resolvers.Query.transitive, `imported component's imported resolver (transitive resolver) is present`);
-    st.ok(resolvers.Query.transitive.__isProxy, `imported component's imported resolver (transitive resolver) is a proxy`);
+    });
+
+    const importedResolvers = getImportedResolvers(component, ['Query.someOtherQuery']);
+    st.ok(importedResolvers.Query.someQuery.__isProxy, 'Query.someQuery is a proxy');
+    st.notOk(importedResolvers.Query.someOtherQuery, 'Query.someOtherQuery was excluded');
+    st.notOk(importedResolvers.SomeType, 'non-root type (SomeType) is not imported')
     st.end();
   });
-});
+
+  t.test(`import component's resolvers that contain an abstract type`, (st) => {
+    const component = new GraphQLComponent({
+      types: `
+        type Query {
+          thing: Thing
+        }
+
+        interface Thing {
+          id: ID
+        }
+
+        type A implements Thing {
+          id: ID
+          fieldForA: String
+        }
+
+        type B implements Thing {
+          id: ID
+          fieldForB: String
+        }
+      `,
+      resolvers: {
+        Query: {
+          thing() {
+            return { id: '1', fieldForA: 'a', fieldForB: 'b'};
+          }
+        },
+        Thing: {
+          __resolveType(thing) {
+            if (thing.fieldForA) {
+              return 'A';
+            } else if (thing.fieldForB) {
+              return 'B';
+            }
+          }
+        }
+      }
+    });
+
+    const importedResolvers = getImportedResolvers(component);
+    st.ok(importedResolvers.Query.thing.__isProxy, 'Query.thing is a proxy');
+    st.ok(importedResolvers.Thing.__resolveType, '__resolveType was pulled up');
+    st.end();
+  });
+})
 
 Test('createProxyResolver()', (t) => {
   const resolver = createProxyResolver(undefined, 'Query', 'test');
   t.strictEqual(resolver.__isProxy, true, 'function returned is a proxy');
   t.end();
 });
-
-Test('createProxyResolvers()', (t) => {
-  t.test('resolver map passed to createProxyResolvers()', (st) => {
-    const resolvers = {
-      Query: {
-        foo() { }
-      },
-      Foo: {
-        bar() { }
-      }
-    };
-  
-    const proxiedResolvers = createProxyResolvers(undefined, resolvers);
-    st.ok(proxiedResolvers.Query.foo.__isProxy, 'root type field resolver is a proxy');
-    st.notOk(proxiedResolvers.Foo, `non root type isn't returned with proxied resolver map`);
-    st.end();
-  });
-});
-

--- a/test/test-types.js
+++ b/test/test-types.js
@@ -87,7 +87,7 @@ Test('type utilities', (t) => {
       `]
     };
 
-    const types = Types.getImportedTypes({}, component, [['Query', 'b']]);
+    const types = Types.getImportedTypes({}, component, ['Query.b']);
     const schemaA = buildASTSchema(types[0]);
     t.ok(schemaA.getType('A').getFields().value, `the "A" type exists in component's schema`);
     t.ok(schemaA.getQueryType().getFields().a, `the "a" query exists in component's schema`);
@@ -114,7 +114,7 @@ Test('type utilities', (t) => {
       `]
     };
 
-    let types = Types.getImportedTypes({}, component, [['Query', 'a']]);
+    let types = Types.getImportedTypes({}, component, ['Query.a']);
     let schema = buildASTSchema(types[0]);
     t.ok(schema.getType('A').getFields().value, `the "A" type exists in component's schema`);
     t.notOk(schema.getQueryType().getFields().a, `the "a" query does not exist in component's schema`);
@@ -144,7 +144,7 @@ Test('type utilities', (t) => {
       `]
     };
 
-    const types = Types.getImportedTypes({}, component, [['*']]);
+    const types = Types.getImportedTypes({}, component, ['*']);
     const schema = buildASTSchema(types[0]);
     t.notOk(schema.getQueryType(), `the "Query" type does not exist in component's schema because all of it's fields were removed`);
     t.notOk(schema.getMutationType(), `the "Mutation" type does not exist in component's schema because all of its fields were removed`);
@@ -177,7 +177,7 @@ Test('type utilities', (t) => {
       `]
     };
 
-    const types = Types.getImportedTypes({}, component, [['Mutation', 'b1'], ['Query', 'b']]);
+    const types = Types.getImportedTypes({}, component, ['Mutation.b1', 'Query.b']);
     const schemaA = buildASTSchema(types[0]);
     t.ok(schemaA.getType('A').getFields().value, `the "A" type exists in component's schema`);
     t.ok(schemaA.getQueryType().getFields().a, `the "a" query exists in component's schema`);


### PR DESCRIPTION
* pulls up __resolveType functions to the parent to fix abstract type issue

* simplifies the import loop in the GraphQLComponent constructor
* minor variable/function renaming for readability
* removes some resolvers module functions and simplifies `getImportedResolvers()`
* adds/modifies supporting unit tests