### PR TITLE
HOLD OFF MERGE: fixing type resolving and delegate field name mapping

### DIFF
--- a/lib/__tests__.js
+++ b/lib/__tests__.js
@@ -141,12 +141,12 @@ Test('delegateToComponent from root type', async (t) => {
         anotherChildField: String
       }
       type Query {
-        child: Child
+        childById: Child
       }
     `,
     resolvers: {
       Query: {
-        child() {
+        childById() {
           return {
             childField: 'Child Field',
             anotherChildField: 'Another Child Field'
@@ -172,6 +172,9 @@ Test('delegateToComponent from root type', async (t) => {
       Query: {
         parent: async function (_, args, context, info) {
           const child = await GraphQLComponent.delegateToComponent(childComponent, {
+            fieldMap: {
+              child: 'childById'
+            },
             subPath: 'child',
             contextValue: context,
             info
@@ -220,8 +223,8 @@ Test('delegateToComponent from root type', async (t) => {
   
   const { parent1, parent2 } = result.data;
 
-  t.deepEqual(parent1, { child: { childField: 'Child Field', addedField: 'Added from Parent', __typename: 'Child' }}, 'received correct first result');
-  t.deepEqual(parent2, { child: { anotherChildField: 'Another Child Field', addedField: 'Added from Parent', __typename: 'Child' }}, 'received correct second result');
+  t.deepEqual(parent1, { child: { childField: 'Child Field', addedField: 'Added from Parent' }}, 'received correct first result');
+  t.deepEqual(parent2, { child: { anotherChildField: 'Another Child Field', addedField: 'Added from Parent' }}, 'received correct second result');
 });
 
 Test('delegateToComponent from type resolver', async (t) => {
@@ -314,8 +317,8 @@ Test('delegateToComponent from type resolver', async (t) => {
   
   const { parent1, parent2 } = result.data;
 
-  t.deepEqual(parent1, { child: { childField: 'Child Field', addedField: 'Added from Parent', __typename: 'Child' }}, 'received correct first result');
-  t.deepEqual(parent2, { child: { anotherChildField: 'Another Child Field', addedField: 'Added from Parent', __typename: 'Child' }}, 'received correct second result');
+  t.deepEqual(parent1, { child: { childField: 'Child Field', addedField: 'Added from Parent', }}, 'received correct first result');
+  t.deepEqual(parent2, { child: { anotherChildField: 'Another Child Field', addedField: 'Added from Parent' }}, 'received correct second result');
 });
 
 Test('mocks', async (t) => {

--- a/lib/resolvers/__tests__.js
+++ b/lib/resolvers/__tests__.js
@@ -453,7 +453,6 @@ Test('importResolvers()', (t) => {
 
     const importedResolvers = importResolvers(component);
     st.ok(importedResolvers.Query.thing.__isProxy, 'Query.thing is a proxy');
-    st.ok(importedResolvers.Thing.__resolveType, '__resolveType was pulled up');
     st.end();
   });
 })

--- a/lib/resolvers/index.js
+++ b/lib/resolvers/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const debug = require('debug')('graphql-component:resolver');
-const { GraphQLScalarType, Kind, execute } = require('graphql');
+const { GraphQLScalarType, Kind, execute, isAbstractType, getNamedType } = require('graphql');
 const deepSet = require('lodash.set');
 
 /**
@@ -143,7 +143,7 @@ const buildPathFromInfo = function (info) {
   return path;
 };
 
-const getSelectionSetForPath = function (fieldPath, selectionSet) {
+const getSelectionSetForPath = function (fieldPath, fieldMap, selectionSet) {
   const getSelection = function (name, selections) {
     for (const selection of selections) {
       if (selection.name.value === name || selection.alias.value === name) {
@@ -160,10 +160,20 @@ const getSelectionSetForPath = function (fieldPath, selectionSet) {
     current = current && getSelection(path, current.selectionSet.selections);
   }
 
-  return current;
+  return current ? {
+    kind: Kind.FIELD,
+    alias: current.alias,
+    name: {
+      name: Kind.NAME,
+      value: fieldMap[current.name.value] || current.name.value
+    },
+    arguments: current.arguments,
+    directives: current.directives,
+    selectionSet: current.selectionSet
+  } : undefined;
 };
 
-const createSubOperationForField = function (component, fieldPath, info) {
+const createSubOperationForField = function (component, fieldPath, fieldMap, info) {
   const operation = info.operation;
   const fragments = info.fragments;
 
@@ -181,17 +191,19 @@ const createSubOperationForField = function (component, fieldPath, info) {
     }
   }
 
-  const selections = getSelectionSetForPath([...fieldPath], operation.selectionSet);
+  const selections = getSelectionSetForPath([...fieldPath], fieldMap, operation.selectionSet);
 
   //Add __typename request for usage in __resolveType
   if (selections && selections.selectionSet) {
-    selections.selectionSet.selections.push({
-      kind: Kind.FIELD,
-      name: {
-        kind: Kind.NAME,
-        value: '__typename'
-      }
-    });
+    if (isAbstractType(getNamedType(info.returnType))) {
+      selections.selectionSet.selections.push({
+        kind: Kind.FIELD,
+        name: {
+          kind: Kind.NAME,
+          value: '__typename'
+        }
+      });
+    }
   }
 
   definitions.push({
@@ -213,13 +225,13 @@ const createSubOperationForField = function (component, fieldPath, info) {
 };
 
 // Eventually accept an argument to map fields for sub-query?
-const delegateToComponent = async function (component, { subPath, contextValue, info }) {
+const delegateToComponent = async function (component, { fieldMap = {}, subPath, contextValue, info }) {
   const rootPath = buildPathFromInfo(info);
   const fieldPath = subPath !== undefined ? [...rootPath, ...subPath.split('.')] : rootPath;
 
   const { rootValue, variableValues } = info;
   
-  const document = createSubOperationForField(component, fieldPath, info);
+  const document = createSubOperationForField(component, fieldPath, fieldMap, info);
   
   const { data = {}, errors = [] } = await execute({ document, schema: component.schema, rootValue, contextValue, variableValues });
   
@@ -236,7 +248,7 @@ const delegateToComponent = async function (component, { subPath, contextValue, 
   
   while (fieldPath.length > 0) {
     let path = fieldPath.shift();
-    result = result[path];
+    result = result[fieldMap[path] || path];
   }
   
   return result;
@@ -295,20 +307,6 @@ const importResolvers = function (component, excludes) {
           resultingResolverMap[type] = {};
         }
         resultingResolverMap[type][field] = createProxyResolver(component, type, field);
-      } else if (field.startsWith('__')) {
-        if (resultingResolverMap[type] === undefined) {
-          resultingResolverMap[type] = {};
-        }
-        
-        // automatically create a __resolveType function at the parent level
-        // that returns the __typename of the prior resolver's result
-        if (field === '__resolveType') {
-          resultingResolverMap[type][field] = function (_) {
-            return _.__typename;
-          }
-        } else {
-          resultingResolverMap[type][field] = resolverFunc;
-        }
       }
     }
   }


### PR DESCRIPTION
The field mapping is POC. Probably a better way to do this.

Also todo: add argument overrides (which may be tricky since it could require type and naming info).

In general, we should probably tie down the patterns of how to use delegate to be fairly strict. This shouldn't be a 1:1 mapping to execute.