### PR TITLE
delegateToComponent clean up

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,16 @@ context.use('transformRawRequest', ({ request }) => {
 
 Using `context` now in `apollo-server-hapi` for example, will transform the context to one similar to default `apollo-server`.
 
-### Delegating sub-query to another component
+### Delegating root-type operations to a component
+GraphQLComponent exposes a static function called `delegateToComponent` that provides functionality for delegating execution of a operation (ie. `query`, `mutation`) to a given component. In general, delegateToComponent is meant to be somewhat opinionated/restrictive in order to encourage more formal links or connections between types defined in seperate components. `delegateToComponent` can be called from a component's root or non-root type field resolvers.
 
-TODO
+#### static delegateToComponent(component, options) => delegated graphql execution result
+* component: the component to delegate execution to
+* options: an object whose properties facilitate delegation of a graphql operation to the input component
+  * `contextValue` (required): the `context` object from resolver that calls `delegateToComponent`
+  * `info` (required): the `info` object from the resolver that calls `delegateToComponent`
+  * `targetRootField` (`string`, optional): if the calling resolver's field name is different from the root field name on the delegatee, you can specify the desired root field on the delegatee that you want to execute
+  * `subPath` (`string`, optional): dot separated string designating a path into the incoming selection set that will limit the selection set in delegated operation
+
+
+

--- a/lib/__tests__.js
+++ b/lib/__tests__.js
@@ -33,7 +33,6 @@ Test('component API', (t) => {
   });
 
   t.test('isComponent with new base class instance', (st) => {
-    console.log(typeof new GraphQLComponent());
     st.ok(GraphQLComponent.isComponent(new GraphQLComponent()), 'is a component');
     st.end();
   });
@@ -90,7 +89,7 @@ Test('component API', (t) => {
       types: `type Query { c: String }`,
       resolvers: { Query: { c() { return 'hello' }}},
       imports: [new GraphQLComponent()]
-    })
+    });
     const root = new GraphQLComponent({
       imports: [
         childThatAlsoHasImports

--- a/lib/__tests__.js
+++ b/lib/__tests__.js
@@ -8,317 +8,134 @@ const GraphQLComponent = require('./index');
 
 Test('component API', (t) => {
 
-  t.plan(1);
+  t.test('component name (anonymous constructor)', (st) => {
+    const component = new GraphQLComponent();
+    t.equals(component.name, 'GraphQLComponent', `unnamed constructor results in component named 'GraphQLComponent'`);
+    st.end();
+  })
 
-  const component = new GraphQLComponent();
-
-  t.ok(component._id, '_id populated.');
-});
-
-Test('component isComponent', (t) => {
-
-  t.test('isComponent not a subclass', (t) => {
-    t.plan(1);
-
-    t.ok(!GraphQLComponent.isComponent(Object.create({ types: [], resolvers: {} })), 'not a subclass');
+  t.test('component name (named constructor)', (st) => {
+    class Named extends GraphQLComponent {}
+    const component = new Named();
+    t.equals(component.name, 'Named', `named constructor results in 'Named'`);
+    st.end();
   });
 
-  t.test('isComponent', (t) => {
-    t.plan(1);
-
-    t.ok(GraphQLComponent.isComponent(new GraphQLComponent()), 'new super class is component');
+  t.test('component id', (st) => {
+    const component = new GraphQLComponent();
+    t.ok(component.id, `got component's id`);
+    st.end();
   });
 
-  t.test('isComponent subclass', (t) => {
-    t.plan(1);
-
-    t.ok(GraphQLComponent.isComponent(new class extends GraphQLComponent { }), 'new subclass is component');
+  t.test('isComponent with config object', (st) => {
+    st.notOk(GraphQLComponent.isComponent(Object.create({ component: new GraphQLComponent, exclude: ['Query.a'] })), 'is not a component');
+    st.end();
   });
 
-});
+  t.test('isComponent with new base class instance', (st) => {
+    console.log(typeof new GraphQLComponent());
+    st.ok(GraphQLComponent.isComponent(new GraphQLComponent()), 'is a component');
+    st.end();
+  });
 
-Test('component resolver delegate', async (t) => {
+  t.test('isComponent with new subclass', (st) => {
+    t.ok(GraphQLComponent.isComponent(new class extends GraphQLComponent { }), 'is a component');
+    st.end();
+  });
 
-  t.plan(1);
+  t.test('component context', (st) => {
+    const component = new GraphQLComponent();
+    const context = component.context;
+    st.ok(typeof context === 'function', 'context is a function');
+    st.ok(typeof context.use === 'function', 'context has a use funtion');
+    st.end();
+  });
 
-  const component = new GraphQLComponent({
-    imports: [
-      new GraphQLComponent({
-        types: `
-          type Test {
-            value: Boolean
-          }
-          type Query {
-            test: Test
-          }
-        `,
+  t.test('component types', (st) => {
+    const component = new GraphQLComponent({
+      types: `type Query { a: String }`,
+      imports: [new GraphQLComponent({
+        types: `type Query { b: B} type B { someField: String}`}
+      )]
+    });
+
+    st.deepEquals(component.types, [`type Query { a: String }`], `only the component's own types are returned (no imports)`);
+    st.end();
+  });
+
+  t.test('component resolvers', (st) => {
+    const component = new GraphQLComponent({
+      resolvers: {
+        Query: {
+          a() { return 'hello'}
+        }
+      },
+      imports: [new GraphQLComponent({
         resolvers: {
           Query: {
-            test() {
-              return {
-                value: true
-              }
+            b() {
+              return 'goodbye';
             }
           }
         }
-      })
-    ]
+      })]
+    });
+
+    st.equals(Object.keys(component.resolvers.Query).length, 1, `only the component's own resolvers are returned`);
+    st.end();
   });
 
-  const { data } = await graphql.execute({
-    document: gql`query { test { value } }`,
-    schema: component.schema,
-    rootValue: undefined,
-    contextValue: {}
-  });
-  
-  t.equal(data.test.value, true, 'resolved');
-});
-
-Test('component resolver delegate errors', async (t) => {
-
-  t.plan(3);
-
-  const component = new GraphQLComponent({
-    imports: [
-      new GraphQLComponent({
-        types: `
-          type Test {
-            value: Boolean
-            err: Boolean
-          }
-          type Query {
-            test: Test
-          }
-        `,
-        resolvers: {
-          Query: {
-            test() {
-              return {
-                value: true,
-                err: true
-              }
-            }
-          },
-          Test: {
-            err(_) {
-              if (_.err) {
-                throw new Error('error');
-              }
-            }
-          }
-        }
-      })
-    ]
+  t.test('component imports', (st) => {
+    const childThatAlsoHasImports = new GraphQLComponent({
+      types: `type Query { c: String }`,
+      resolvers: { Query: { c() { return 'hello' }}},
+      imports: [new GraphQLComponent()]
+    })
+    const root = new GraphQLComponent({
+      imports: [
+        childThatAlsoHasImports
+      ]
+    });
+    st.equals(root.imports.length, 1, `only component's own imports are returned`);
+    st.equals(childThatAlsoHasImports.id, root.imports[0].component.id, `id of only import matches import instance's id`);
+    st.end();
   });
 
-  const document = gql`
-    query { 
-      foo: test { value, err } 
-      bar: test { value }
-    }`;
+  t.test('component mocks', (st) => {
+    const component = new GraphQLComponent({
+      mocks: { Query: { mockA() { return 'mockAString' }}},
+      imports: [new GraphQLComponent({
+        mocks: { Query: { mockB() { return 'mockBString' }}}
+      })]
+    });
 
-  const { data, errors } = await graphql.execute({
-    document,
-    schema: component.schema,
-    rootValue: undefined,
-    contextValue: {}
+    st.equals(Object.keys(component.mocks).length, 1, `only component's own mocks are returned`);
+    st.end();
   });
 
-  t.equal(data.foo.value, true, 'resolved alias 1');
-  t.equal(data.bar.value, true, 'resolved alias 2');
-  t.ok(errors && errors.length > 0, 'got error');
-});
+  t.test('component directives', (st) => {
+    const component = new GraphQLComponent({
+      directives: { parentDirective: () => {}},
+      imports: [new GraphQLComponent({
+        directives: { childDirective: () => {}}
+      })]
+    });
 
-Test('delegateToComponent from root type', async (t) => {
-
-  t.plan(3);
-
-  const childComponent = new GraphQLComponent({
-    types: `
-      type Child {
-        childField: String
-        anotherChildField: String
-      }
-      type Query {
-        childById: Child
-      }
-    `,
-    resolvers: {
-      Query: {
-        childById() {
-          return {
-            childField: 'Child Field',
-            anotherChildField: 'Another Child Field'
-          }
-        }
-      }
-    }
+    st.equals(Object.keys(component.directives).length, 1, `only component's own directives are returned`);
+    st.end();
   });
 
-  const component = new GraphQLComponent({
-    types: `
-      type Parent {
-        child: Child
-      }
-      type Child {
-        addedField: String
-      }
-      type Query {
-        parent: Parent
-      }
-    `,
-    resolvers: {
-      Query: {
-        parent: async function (_, args, context, info) {
-          const child = await GraphQLComponent.delegateToComponent(childComponent, {
-            fieldMap: {
-              child: 'childById'
-            },
-            subPath: 'child',
-            contextValue: context,
-            info
-          });
+  t.test('component datasources', (st) => {
+    const component = new GraphQLComponent({
+      dataSources: ['parentDataSourcePlaceHolder'],
+      imports: [new GraphQLComponent({
+        dataSources: ['childDataSourcePlaceHolder']
+      })]
+    });
 
-          return {
-            child
-          };
-        }
-      },
-      Child: {
-        addedField() {
-          return 'Added from Parent'
-        }
-      }
-    },
-    imports: [
-      childComponent
-    ]
+    st.equals(Object.keys(component.dataSources).length, 1, `only component's own dataSources are returned`);
+    st.end();
   });
-
-  const document = gql`
-    query { 
-      parent1: parent {
-        child {
-          childField
-          addedField
-        }
-      }
-      parent2: parent {
-        child {
-          anotherChildField
-          addedField
-        }
-      }
-    }`;
-
-  const result = await graphql.execute({
-    document,
-    schema: component.schema,
-    rootValue: undefined,
-    contextValue: {}
-  });
-
-  t.ok(!result.errors, 'no errors');
-  
-  const { parent1, parent2 } = result.data;
-
-  t.deepEqual(parent1, { child: { childField: 'Child Field', addedField: 'Added from Parent' }}, 'received correct first result');
-  t.deepEqual(parent2, { child: { anotherChildField: 'Another Child Field', addedField: 'Added from Parent' }}, 'received correct second result');
-});
-
-Test('delegateToComponent from type resolver', async (t) => {
-
-  t.plan(3);
-
-  const childComponent = new GraphQLComponent({
-    types: `
-      type Child {
-        childField: String
-        anotherChildField: String
-      }
-      type Query {
-        child: Child
-      }
-    `,
-    resolvers: {
-      Query: {
-        child() {
-          return {
-            childField: 'Child Field',
-            anotherChildField: 'Another Child Field'
-          }
-        }
-      }
-    }
-  });
-
-  const component = new GraphQLComponent({
-    types: `
-      type Parent {
-        child: Child
-      }
-      type Child {
-        addedField: String
-      }
-      type Query {
-        parent: Parent
-      }
-    `,
-    resolvers: {
-      Query: {
-        parent: async function () {
-          return {};
-        }
-      },
-      Parent: {
-        child(_, args, context, info) {
-          return GraphQLComponent.delegateToComponent(childComponent, {
-            contextValue: context,
-            info
-          });
-        }
-      },
-      Child: {
-        addedField() {
-          return 'Added from Parent'
-        }
-      }
-    },
-    imports: [
-      childComponent
-    ]
-  });
-
-  const document = gql`
-    query { 
-      parent1: parent {
-        child {
-          childField
-          addedField
-        }
-      }
-      parent2: parent {
-        child {
-          anotherChildField
-          addedField
-        }
-      }
-    }`;
-
-  const result = await graphql.execute({
-    document,
-    schema: component.schema,
-    rootValue: undefined,
-    contextValue: {}
-  });
-
-  t.ok(!result.errors, 'no errors');
-  
-  const { parent1, parent2 } = result.data;
-
-  t.deepEqual(parent1, { child: { childField: 'Child Field', addedField: 'Added from Parent', }}, 'received correct first result');
-  t.deepEqual(parent2, { child: { anotherChildField: 'Another Child Field', addedField: 'Added from Parent' }}, 'received correct second result');
 });
 
 Test('mocks', async (t) => {
@@ -489,136 +306,3 @@ Test('integration: data source', (t) => {
   
 });
 
-Test('proxy to child with root query that returns interface type (using __resolveType())', async (t) => {
-  const child = new GraphQLComponent({
-    types: `
-      type Query {
-        things: [Thing]
-      }
-      interface Thing {
-        id: ID
-      }
-      type Person implements Thing {
-        id: ID
-        name: String
-      }
-      type Animal implements Thing {
-        id: ID
-        someField: Int
-      }
-    `,
-    resolvers: {
-      Query: {
-        things() {
-          return [
-            {
-              id: '1',
-              name: 'Joe Smith'
-            }
-          ]
-        }
-      },
-      Thing: {
-        __resolveType(parent) {
-          if (parent.name) {
-            return 'Person';
-          }
-          return 'Animal';
-        }
-      }
-    }
-  });
-
-  const parent = new GraphQLComponent({
-    imports: [
-      child
-    ]
-  });
-
-  const result = await graphql.execute({
-    document: gql`
-      query {
-        things {
-          id
-          ... on Person {
-            name
-          }
-        }
-      }
-    `,
-    schema: parent.schema,
-    contextValue: {}
-  });
-
-  t.deepEquals(result.data.things, [{ id: '1', name: 'Joe Smith', __typename: 'Person' }], 'interface type resolved')
-  t.notOk(result.errors, 'no errors');
-  t.end();
-});
-
-Test('proxy to child with root query that returns interface type (using __isTypeOf())', async (t) => {
-  const child = new GraphQLComponent({
-    types: `
-      type Query {
-        things: [Thing]
-      }
-      interface Thing {
-        id: ID
-      }
-      type Person implements Thing {
-        id: ID
-        name: String
-      }
-      type Animal implements Thing {
-        id: ID
-        someField: Int
-      }
-    `,
-    resolvers: {
-      Query: {
-        things() {
-          return [
-            {
-              id: '1',
-              name: 'Joe Smith'
-            }
-          ]
-        }
-      },
-      Person: {
-        __isTypeOf() {
-          return 'Person'
-        }
-      },
-      Animal: {
-        __isTypeOf() {
-          return 'Animal';
-        }
-      }
-    }
-  });
-
-  const parent = new GraphQLComponent({
-    imports: [
-      child
-    ]
-  });
-
-  const result = await graphql.execute({
-    document: gql`
-      query {
-        things {
-          id
-          ... on Person {
-            name
-          }
-        }
-      }
-    `,
-    schema: parent.schema,
-    contextValue: {}
-  });
-
-  t.deepEquals(result.data.things, [{ id: '1', name: 'Joe Smith', __typename: 'Person' }], 'interface type resolved')
-  t.notOk(result.errors, 'no errors');
-  t.end();
-});

--- a/lib/__tests__.js
+++ b/lib/__tests__.js
@@ -141,12 +141,12 @@ Test('delegateToComponent from root type', async (t) => {
         anotherChildField: String
       }
       type Query {
-        child: Child
+        childById: Child
       }
     `,
     resolvers: {
       Query: {
-        child() {
+        childById() {
           return {
             childField: 'Child Field',
             anotherChildField: 'Another Child Field'
@@ -172,6 +172,9 @@ Test('delegateToComponent from root type', async (t) => {
       Query: {
         parent: async function (_, args, context, info) {
           const child = await GraphQLComponent.delegateToComponent(childComponent, {
+            fieldMap: {
+              child: 'childById'
+            },
             subPath: 'child',
             contextValue: context,
             info
@@ -220,8 +223,8 @@ Test('delegateToComponent from root type', async (t) => {
   
   const { parent1, parent2 } = result.data;
 
-  t.deepEqual(parent1, { child: { childField: 'Child Field', addedField: 'Added from Parent', __typename: 'Child' }}, 'received correct first result');
-  t.deepEqual(parent2, { child: { anotherChildField: 'Another Child Field', addedField: 'Added from Parent', __typename: 'Child' }}, 'received correct second result');
+  t.deepEqual(parent1, { child: { childField: 'Child Field', addedField: 'Added from Parent' }}, 'received correct first result');
+  t.deepEqual(parent2, { child: { anotherChildField: 'Another Child Field', addedField: 'Added from Parent' }}, 'received correct second result');
 });
 
 Test('delegateToComponent from type resolver', async (t) => {
@@ -314,8 +317,8 @@ Test('delegateToComponent from type resolver', async (t) => {
   
   const { parent1, parent2 } = result.data;
 
-  t.deepEqual(parent1, { child: { childField: 'Child Field', addedField: 'Added from Parent', __typename: 'Child' }}, 'received correct first result');
-  t.deepEqual(parent2, { child: { anotherChildField: 'Another Child Field', addedField: 'Added from Parent', __typename: 'Child' }}, 'received correct second result');
+  t.deepEqual(parent1, { child: { childField: 'Child Field', addedField: 'Added from Parent', }}, 'received correct first result');
+  t.deepEqual(parent2, { child: { anotherChildField: 'Another Child Field', addedField: 'Added from Parent' }}, 'received correct second result');
 });
 
 Test('mocks', async (t) => {

--- a/lib/delegate/__tests__.js
+++ b/lib/delegate/__tests__.js
@@ -1,0 +1,357 @@
+const Test = require('tape');
+const gql = require('graphql-tag');
+const graphql = require('graphql');
+const GraphQLComponent = require('../');
+
+Test('integration - automatic child root resolver proxying via delegateToComponent', async (t) => {
+
+  t.plan(1);
+
+  const component = new GraphQLComponent({
+    imports: [
+      new GraphQLComponent({
+        types: `
+          type Test {
+            value: Boolean
+          }
+          type Query {
+            test: Test
+          }
+        `,
+        resolvers: {
+          Query: {
+            test() {
+              return {
+                value: true
+              }
+            }
+          }
+        }
+      })
+    ]
+  });
+
+  const { data } = await graphql.execute({
+    document: gql`query { test { value } }`,
+    schema: component.schema,
+    rootValue: undefined,
+    contextValue: {}
+  });
+  
+  t.equal(data.test.value, true, 'resolved');
+});
+
+Test('delegateToComponent from root type', async (t) => {
+
+  t.plan(3);
+
+  const childComponent = new GraphQLComponent({
+    types: `
+      type Child {
+        childField: String
+        anotherChildField: String
+      }
+      type Query {
+        childById: Child
+      }
+    `,
+    resolvers: {
+      Query: {
+        childById() {
+          return {
+            childField: 'Child Field',
+            anotherChildField: 'Another Child Field'
+          }
+        }
+      }
+    }
+  });
+
+  const component = new GraphQLComponent({
+    types: `
+      type Parent {
+        child: Child
+      }
+      type Child {
+        addedField: String
+      }
+      type Query {
+        parent: Parent
+      }
+    `,
+    resolvers: {
+      Query: {
+        parent: async function (_, args, context, info) {
+          const child = await GraphQLComponent.delegateToComponent(childComponent, {
+            fieldMap: {
+              child: 'childById'
+            },
+            subPath: 'child',
+            contextValue: context,
+            info
+          });
+
+          return {
+            child
+          };
+        }
+      },
+      Child: {
+        addedField() {
+          return 'Added from Parent'
+        }
+      }
+    },
+    imports: [
+      childComponent
+    ]
+  });
+
+  const document = gql`
+    query { 
+      parent1: parent {
+        child {
+          childField
+          addedField
+        }
+      }
+      parent2: parent {
+        child {
+          anotherChildField
+          addedField
+        }
+      }
+    }`;
+
+  const result = await graphql.execute({
+    document,
+    schema: component.schema,
+    rootValue: undefined,
+    contextValue: {}
+  });
+
+  t.ok(!result.errors, 'no errors');
+  
+  const { parent1, parent2 } = result.data;
+
+  t.deepEqual(parent1, { child: { childField: 'Child Field', addedField: 'Added from Parent' }}, 'received correct first result');
+  t.deepEqual(parent2, { child: { anotherChildField: 'Another Child Field', addedField: 'Added from Parent' }}, 'received correct second result');
+});
+
+Test('delegateToComponent from type resolver', async (t) => {
+
+  t.plan(3);
+
+  const childComponent = new GraphQLComponent({
+    types: `
+      type Child {
+        childField: String
+        anotherChildField: String
+      }
+      type Query {
+        child: Child
+      }
+    `,
+    resolvers: {
+      Query: {
+        child() {
+          return {
+            childField: 'Child Field',
+            anotherChildField: 'Another Child Field'
+          }
+        }
+      }
+    }
+  });
+
+  const component = new GraphQLComponent({
+    types: `
+      type Parent {
+        child: Child
+      }
+      type Child {
+        addedField: String
+      }
+      type Query {
+        parent: Parent
+      }
+    `,
+    resolvers: {
+      Query: {
+        parent: async function () {
+          return {};
+        }
+      },
+      Parent: {
+        child(_, args, context, info) {
+          return GraphQLComponent.delegateToComponent(childComponent, {
+            contextValue: context,
+            info
+          });
+        }
+      },
+      Child: {
+        addedField() {
+          return 'Added from Parent'
+        }
+      }
+    },
+    imports: [
+      childComponent
+    ]
+  });
+
+  const document = gql`
+    query { 
+      parent1: parent {
+        child {
+          childField
+          addedField
+        }
+      }
+      parent2: parent {
+        child {
+          anotherChildField
+          addedField
+        }
+      }
+    }`;
+
+  const result = await graphql.execute({
+    document,
+    schema: component.schema,
+    rootValue: undefined,
+    contextValue: {}
+  });
+
+  t.ok(!result.errors, 'no errors');
+  
+  const { parent1, parent2 } = result.data;
+
+  t.deepEqual(parent1, { child: { childField: 'Child Field', addedField: 'Added from Parent', }}, 'received correct first result');
+  t.deepEqual(parent2, { child: { anotherChildField: 'Another Child Field', addedField: 'Added from Parent' }}, 'received correct second result');
+});
+
+Test('delegateToComponent with errors', async (t) => {
+
+  t.plan(3);
+
+  const component = new GraphQLComponent({
+    imports: [
+      new GraphQLComponent({
+        types: `
+          type Test {
+            value: Boolean
+            err: Boolean
+          }
+          type Query {
+            test: Test
+          }
+        `,
+        resolvers: {
+          Query: {
+            test() {
+              return {
+                value: true,
+                err: true
+              }
+            }
+          },
+          Test: {
+            err(_) {
+              if (_.err) {
+                throw new Error('error');
+              }
+            }
+          }
+        }
+      })
+    ]
+  });
+
+  const document = gql`
+    query { 
+      foo: test { value, err } 
+      bar: test { value }
+    }`;
+
+  const { data, errors } = await graphql.execute({
+    document,
+    schema: component.schema,
+    rootValue: undefined,
+    contextValue: {}
+  });
+
+  t.equal(data.foo.value, true, 'resolved alias 1');
+  t.equal(data.bar.value, true, 'resolved alias 2');
+  t.ok(errors && errors.length > 0, 'got error');
+});
+
+Test('delegateToComponent - return type is abstract', async (t) => {
+  let resolveTypeCallCount = 0;
+  const child = new GraphQLComponent({
+    types: `
+      type Query {
+        things: [Thing]
+      }
+      interface Thing {
+        id: ID
+      }
+      type Person implements Thing {
+        id: ID
+        name: String
+      }
+      type Animal implements Thing {
+        id: ID
+        someField: Int
+      }
+    `,
+    resolvers: {
+      Query: {
+        things() {
+          return [
+            {
+              id: '1',
+              name: 'Joe Smith'
+            }
+          ]
+        }
+      },
+      Thing: {
+        __resolveType(parent) {
+          resolveTypeCallCount = resolveTypeCallCount + 1;
+          if (parent.name) {
+            return 'Person';
+          }
+          return 'Animal';
+        }
+      }
+    }
+  });
+
+  const parent = new GraphQLComponent({
+    imports: [
+      child
+    ]
+  });
+
+  const result = await graphql.execute({
+    document: gql`
+      query {
+        things {
+          id
+          ... on Person {
+            name
+          }
+        }
+      }
+    `,
+    schema: parent.schema,
+    contextValue: {}
+  });
+
+  t.deepEquals(result.data.things, [{ id: '1', name: 'Joe Smith', __typename: 'Person' }], 'interface type resolved');
+  t.equals(resolveTypeCallCount, 1, '__resolveType called in child once per item in list');
+  t.notOk(result.errors, 'no errors');
+  t.end();
+});

--- a/lib/delegate/__tests__.js
+++ b/lib/delegate/__tests__.js
@@ -3,11 +3,11 @@ const gql = require('graphql-tag');
 const graphql = require('graphql');
 const GraphQLComponent = require('../');
 
-Test('integration - automatic proxy to child root resolver from parent via delegateToComponent', async (t) => {
+Test('integration - composite automatically delegates to root primitive field via delegateToComponent', async (t) => {
 
   t.plan(1);
 
-  const component = new GraphQLComponent({
+  const composite = new GraphQLComponent({
     imports: [
       new GraphQLComponent({
         types: `
@@ -33,7 +33,7 @@ Test('integration - automatic proxy to child root resolver from parent via deleg
 
   const { data } = await graphql.execute({
     document: gql`query { test { value } }`,
-    schema: component.schema,
+    schema: composite.schema,
     rootValue: undefined,
     contextValue: {}
   });
@@ -41,67 +41,67 @@ Test('integration - automatic proxy to child root resolver from parent via deleg
   t.equal(data.test.value, true, 'resolved');
 });
 
-Test('delegateToComponent from root type resolver to child with same name and no subpath', async (t) => {
-  const childComponent = new GraphQLComponent({
+Test('composite component delegates from root type resolver to primitive component field with same name, no sub path', async (t) => {
+  const primitive = new GraphQLComponent({
     types: `
-      type Child {
-        childField: String
-        anotherChildField: String
+      type A {
+        aField: String
+        anotherAField: String
       }
       type Query {
-        child: Child
+        a: A
       }
     `,
     resolvers: {
       Query: {
-        child() {
+        a() {
           return {
-            childField: 'Child Field',
-            anotherChildField: 'Another Child Field'
+            aField: 'a field',
+            anotherAField: 'another a field'
           }
         }
       }
     }
   });
 
-  const component = new GraphQLComponent({
+  const composite = new GraphQLComponent({
     types: `
-      type Child {
+      type A {
         addedField: String
       }
       type Query {
-        child: Child
+        a: A
       }
     `,
     resolvers: {
       Query: {
-        child: async function (_, _args, context, info) {
-          return GraphQLComponent.delegateToComponent(childComponent, {
+        a: async function (_, _args, context, info) {
+          return GraphQLComponent.delegateToComponent(primitive, {
             contextValue: context,
             info
           });
         }
       },
-      Child: {
+      A: {
         addedField() {
-          return 'Added from Parent'
+          return 'added field'
         }
       }
     },
     imports: [
-      childComponent
+      primitive
     ]
   });
 
   const document = gql`
     query { 
-      parent1: child {
-        childField
+      composite1: a {
+        aField
         addedField
       }
         
-      parent2: child {
-        anotherChildField
+      composite2: a {
+        anotherAField
         addedField
       }
     }
@@ -109,82 +109,82 @@ Test('delegateToComponent from root type resolver to child with same name and no
 
   const result = await graphql.execute({
     document,
-    schema: component.schema,
+    schema: composite.schema,
     rootValue: undefined,
     contextValue: {}
   });
 
   t.ok(!result.errors, 'no errors');
   
-  const { parent1, parent2 } = result.data;
+  const { composite1, composite2 } = result.data;
 
-  t.deepEqual(parent1, { childField: 'Child Field', addedField: 'Added from Parent' }, 'received correct first result');
-  t.deepEqual(parent2, { anotherChildField: 'Another Child Field', addedField: 'Added from Parent' }, 'received correct second result');
+  t.deepEqual(composite1, { aField: 'a field', addedField: 'added field' }, 'received correct first result');
+  t.deepEqual(composite2, { anotherAField: 'another a field', addedField: 'added field' }, 'received correct second result');
   t.end();
 });
 
-Test('delegateToComponent from root type resolver to child with different name and no subpath', async (t) => {
-  const childComponent = new GraphQLComponent({
+Test('composite delegates from root type resolver to primitive component field with different name, no sub path', async (t) => {
+  const primitive = new GraphQLComponent({
     types: `
-      type Child {
-        childField: String
-        anotherChildField: String
+      type A {
+        aField: String
+        anotherAField: String
       }
       type Query {
-        child: Child
+        a: A
       }
     `,
     resolvers: {
       Query: {
-        child() {
+        a() {
           return {
-            childField: 'Child Field',
-            anotherChildField: 'Another Child Field'
+            aField: 'a field',
+            anotherAField: 'another a field'
           }
         }
       }
     }
   });
 
-  const component = new GraphQLComponent({
+  const composite = new GraphQLComponent({
     types: `
-      type Child {
+      type A {
         addedField: String
       }
       type Query {
-        parent: Child
+        b: A
       }
     `,
     resolvers: {
       Query: {
-        parent: async function (_, _args, context, info) {
-          return GraphQLComponent.delegateToComponent(childComponent, {
-            targetRootField: 'child',
+        b: async function (_, _args, context, info) {
+          return GraphQLComponent.delegateToComponent(primitive, {
+            targetRootField: 'a',
             contextValue: context,
             info
           });
         }
       },
-      Child: {
+      A: {
         addedField() {
-          return 'Added from Parent'
+          return 'added field'
         }
       }
     },
     imports: [
-      childComponent
+      primitive
     ]
   });
 
   const document = gql`
     query { 
-      parent1: parent {
-        childField
+      composite1: b {
+        aField
         addedField
       }
         
-      parent2: parent {
-        anotherChildField
+      composite2: b {
+        anotherAField
         addedField
       }
     }
@@ -192,98 +192,98 @@ Test('delegateToComponent from root type resolver to child with different name a
 
   const result = await graphql.execute({
     document,
-    schema: component.schema,
+    schema: composite.schema,
     rootValue: undefined,
     contextValue: {}
   });
 
   t.ok(!result.errors, 'no errors');
   
-  const { parent1, parent2 } = result.data;
+  const { composite1, composite2 } = result.data;
 
-  t.deepEqual(parent1, { childField: 'Child Field', addedField: 'Added from Parent' }, 'received correct first result');
-  t.deepEqual(parent2, { anotherChildField: 'Another Child Field', addedField: 'Added from Parent' }, 'received correct second result');
+  t.deepEqual(composite1, { aField: 'a field', addedField: 'added field' }, 'received correct first result');
+  t.deepEqual(composite2, { anotherAField: 'another a field', addedField: 'added field' }, 'received correct second result');
   t.end();
 });
 
-Test('delegateToComponent from root type resolver to child with different name and sub path', async (t) => {
-  const childComponent = new GraphQLComponent({
+Test('composite component delegates from root type resolver to primitive component field with different name, with sub path', async (t) => {
+  const primitive = new GraphQLComponent({
     types: `
-      type Child {
-        childField: String
-        anotherChildField: String
+      type A {
+        aField: String
+        anotherAField: String
       }
       type Query {
-        child: Child
+        a: A
       }
     `,
     resolvers: {
       Query: {
-        child(_root, _args, _context, info) {
+        a(_root, _args, _context, info) {
           const selections = info.fieldNodes[0].selectionSet.selections.map((selectionNode) => { return selectionNode.name.value});
-          t.equals(selections.indexOf('parentField'), -1, 'parent field not in sub path not included in child selection set');
+          t.equals(selections.indexOf('bField'), -1, 'parent field not in sub path not included in child selection set');
           return {
-            childField: 'Child Field',
-            anotherChildField: 'Another Child Field'
+            aField: 'a field',
+            anotherAField: 'another a field'
           }
         }
       }
     }
   });
 
-  const component = new GraphQLComponent({
+  const composite = new GraphQLComponent({
     types: `
       type Query {
-        parent: Parent
+        b: B
       }
-      type Child {
+      type A {
         addedField: String
       }
-      type Parent {
-        parentField: String
-        child: Child
+      type B {
+        bField: String
+        a: A
       }
     `,
     resolvers: {
       Query: {
-        parent: async function (_, _args, context, info) {
-          const child = GraphQLComponent.delegateToComponent(childComponent, {
-            targetRootField: 'child',
-            subPath: 'child',
+        b: async function (_, _args, context, info) {
+          const a = GraphQLComponent.delegateToComponent(primitive, {
+            targetRootField: 'a',
+            subPath: 'a',
             contextValue: context,
             info
           });
           return {
-            parentField: 'parentField',
-            child
+            bField: 'b field',
+            a
           }
         }
       },
-      Child: {
+      A: {
         addedField() {
-          return 'Added from Parent'
+          return 'added field';
         }
       }
     },
     imports: [
-      childComponent
+      primitive
     ]
   });
 
   const document = gql`
     query { 
-      parent1: parent {
-        parentField
-        child { 
-          childField
-          addedField
+      composite1: b {
+        bField
+        a { 
+          aField
+          anotherAField
         }
       }
         
-      parent2: parent {
-        parentField
-        child {
-          anotherChildField
+      composite2: b {
+        bField
+        a {
+          anotherAField
           addedField
         }
       }
@@ -292,91 +292,91 @@ Test('delegateToComponent from root type resolver to child with different name a
 
   const result = await graphql.execute({
     document,
-    schema: component.schema,
+    schema: composite.schema,
     rootValue: undefined,
     contextValue: {}
   });
 
   t.notOk(result.errors, 'no errors');
   
-  const { parent1, parent2 } = result.data;
+  const { composite1, composite2 } = result.data;
 
-  t.deepEqual(parent1, { parentField: 'parentField', child: { childField: 'Child Field', addedField: 'Added from Parent' }}, 'received correct first result');
-  t.deepEqual(parent2, { parentField: 'parentField', child: {anotherChildField: 'Another Child Field', addedField: 'Added from Parent' }}, 'received correct second result');
+  t.deepEqual(composite1, { bField: 'b field', a: { aField: 'a field', anotherAField: 'another a field' }}, 'received correct first result');
+  t.deepEqual(composite2, { bField: 'b field', a: { anotherAField: 'another a field', addedField: 'added field' }}, 'received correct second result');
   t.end();
 });
 
-Test('delegateToComponent from non-root type resolver to child with same name and no sub path', async (t) => {
-  const childComponent = new GraphQLComponent({
+Test('composite component delegates from non-root type resolver to primitive component field with same name, no sub path', async (t) => {
+  const primitive = new GraphQLComponent({
     types: `
-      type Child {
-        childField: String
-        anotherChildField: String
+      type A {
+        aField: String
+        anotherAField: String
       }
       type Query {
-        child: Child
+        a: A
       }
     `,
     resolvers: {
       Query: {
-        child() {
+        a() {
           return {
-            childField: 'Child Field',
-            anotherChildField: 'Another Child Field'
+            aField: 'a field',
+            anotherAField: 'another a field'
           }
         }
       }
     }
   });
 
-  const component = new GraphQLComponent({
+  const composite = new GraphQLComponent({
     types: `
-      type Parent {
-        child: Child
+      type B {
+        a: A
       }
-      type Child {
+      type A {
         addedField: String
       }
       type Query {
-        parent: Parent
+        b: B
       }
     `,
     resolvers: {
       Query: {
-        parent: async function () {
+        b: async function () {
           return {};
         }
       },
-      Parent: {
-        child(_, args, context, info) {
-          return GraphQLComponent.delegateToComponent(childComponent, {
+      B: {
+        a(_, args, context, info) {
+          return GraphQLComponent.delegateToComponent(primitive, {
             contextValue: context,
             info
           });
         }
       },
-      Child: {
+      A: {
         addedField() {
-          return 'Added from Parent'
+          return 'added field'
         }
       }
     },
     imports: [
-      childComponent
+      primitive
     ]
   });
 
   const document = gql`
     query { 
-      parent1: parent {
-        child {
-          childField
+      composite1: b {
+        a {
+          aField
           addedField
         }
       }
-      parent2: parent {
-        child {
-          anotherChildField
+      composite2: b {
+        a {
+          anotherAField
           addedField
         }
       }
@@ -384,92 +384,92 @@ Test('delegateToComponent from non-root type resolver to child with same name an
 
   const result = await graphql.execute({
     document,
-    schema: component.schema,
+    schema: composite.schema,
     rootValue: undefined,
     contextValue: {}
   });
 
   t.ok(!result.errors, 'no errors');
   
-  const { parent1, parent2 } = result.data;
+  const { composite1, composite2 } = result.data;
 
-  t.deepEqual(parent1, { child: { childField: 'Child Field', addedField: 'Added from Parent', }}, 'received correct first result');
-  t.deepEqual(parent2, { child: { anotherChildField: 'Another Child Field', addedField: 'Added from Parent' }}, 'received correct second result');
+  t.deepEqual(composite1, { a: { aField: 'a field', addedField: 'added field', }}, 'received correct first result');
+  t.deepEqual(composite2, { a: { anotherAField: 'another a field', addedField: 'added field' }}, 'received correct second result');
   t.end();
 });
 
-Test('delegateToComponent from non-root type resolver to child with different name and no sub path', async (t) => {
-  const childComponent = new GraphQLComponent({
+Test('composite component delegates from non-root type resolver to primitive component field with different name, no sub path', async (t) => {
+  const primitive = new GraphQLComponent({
     types: `
-      type Child {
-        childField: String
-        anotherChildField: String
+      type A {
+        aField: String
+        anotherAField: String
       }
       type Query {
-        child: Child
+        a: A
       }
     `,
     resolvers: {
       Query: {
-        child() {
+        a() {
           return {
-            childField: 'Child Field',
-            anotherChildField: 'Another Child Field'
+            aField: 'a field',
+            anotherAField: 'another a field'
           }
         }
       }
     }
   });
 
-  const component = new GraphQLComponent({
+  const composite = new GraphQLComponent({
     types: `
-      type Parent {
-        someParentField: Child
+      type B {
+        bField: A
       }
-      type Child {
+      type A {
         addedField: String
       }
       type Query {
-        parent: Parent
+        b: B
       }
     `,
     resolvers: {
       Query: {
-        parent: async function () {
+        b: async function () {
           return {};
         }
       },
-      Parent: {
-        someParentField(_, args, context, info) {
-          return GraphQLComponent.delegateToComponent(childComponent, {
-            targetRootField: 'child',
+      B: {
+        bField(_, args, context, info) {
+          return GraphQLComponent.delegateToComponent(primitive, {
+            targetRootField: 'a',
             contextValue: context,
             info
           });
         }
       },
-      Child: {
+      A: {
         addedField() {
-          return 'Added from Parent'
+          return 'added field'
         }
       }
     },
     imports: [
-      childComponent
+      primitive
     ]
   });
 
   const document = gql`
     query { 
-      parent1: parent {
-        someParentField {
-          childField
+      composite1: b {
+        bField {
+          aField
           addedField
         }
       }
-      parent2: parent {
-        someParentField {
-          anotherChildField
+      composite2: b {
+        bField {
+          anotherAField
           addedField
         }
       }
@@ -477,97 +477,97 @@ Test('delegateToComponent from non-root type resolver to child with different na
 
   const result = await graphql.execute({
     document,
-    schema: component.schema,
+    schema: composite.schema,
     rootValue: undefined,
     contextValue: {}
   });
 
   t.ok(!result.errors, 'no errors');
   
-  const { parent1, parent2 } = result.data;
+  const { composite1, composite2 } = result.data;
 
-  t.deepEqual(parent1, { someParentField: { childField: 'Child Field', addedField: 'Added from Parent', }}, 'received correct first result');
-  t.deepEqual(parent2, { someParentField: { anotherChildField: 'Another Child Field', addedField: 'Added from Parent' }}, 'received correct second result');
+  t.deepEqual(composite1, { bField: { aField: 'a field', addedField: 'added field', }}, 'received correct first result');
+  t.deepEqual(composite2, { bField: { anotherAField: 'another a field', addedField: 'added field' }}, 'received correct second result');
   t.end();
 });
 
-Test('delegateToComponent from non-root type resolver to child with different name and sub path', async (t) => {
-  const childComponent = new GraphQLComponent({
+Test('composite component delegates from non-root type resolver to primitive component field with different name, with sub path', async (t) => {
+  const primitive = new GraphQLComponent({
     types: `
-      type Child {
-        childField: String
-        anotherChildField: String
+      type A {
+        aField: String
+        anotherAField: String
       }
       type Query {
-        child: Child
+        a: A
       }
     `,
     resolvers: {
       Query: {
-        child(_root, _args, _context, info) {
+        a(_root, _args, _context, info) {
           const selections = info.fieldNodes[0].selectionSet.selections.map((selectionNode) => { return selectionNode.name.value});
-          t.equals(selections.indexOf('sopt'), -1, 'parent field not in sub path not included in child selection set');
+          t.equals(selections.indexOf('compositeBField'), -1, 'parent field not in sub path not included in child selection set');
           return {
-            childField: 'Child Field',
-            anotherChildField: 'Another Child Field'
+            aField: 'a field',
+            anotherAField: 'another a field'
           }
         }
       }
     }
   });
 
-  const component = new GraphQLComponent({
+  const composite = new GraphQLComponent({
     types: `
       type Query {
-        parent: Parent
+        b: B
       }
-      type Child {
+      type A {
         addedField: String
       }
-      type SomeOtherParentType {
-        sopt: String
-        child: Child
+      type CompositeB {
+        compositeBField: String
+        a: A
       }
-      type Parent {
-        someOtherParentType: SomeOtherParentType
+      type B {
+        compositeB: CompositeB
       }
     `,
     resolvers: {
       Query: {
-        parent: async function (){
+        b: async function (){
           return {}
         }
       },
-      Parent: {
-        someOtherParentType(root, args, context, info) {
-          const child = GraphQLComponent.delegateToComponent(childComponent, {
-            targetRootField: 'child',
-            subPath: 'child',
+      B: {
+        async compositeB(_root, _args, context, info) {
+          const a = GraphQLComponent.delegateToComponent(primitive, {
+            targetRootField: 'a',
+            subPath: 'a',
             contextValue: context,
             info
           });
-          return { sopt: 'some other parent type value', child }
+          return { compositeBField: 'composite b field', a }
         }
       },
-      Child: {
+      A: {
         addedField() {
-          return 'Added from Parent'
+          return 'added field'
         }
       }
     },
     imports: [
-      childComponent
+      primitive
     ]
   });
 
   const document = gql`
     query {
-      parent {
-        someOtherParentType {
-          sopt
-          child {
-            childField
-            anotherChildField
+      b {
+        compositeB {
+          compositeBField
+          a {
+            aField
+            anotherAField
             addedField
           }
         }
@@ -577,13 +577,13 @@ Test('delegateToComponent from non-root type resolver to child with different na
 
   const result = await graphql.execute({
     document,
-    schema: component.schema,
+    schema: composite.schema,
     rootValue: undefined,
     contextValue: {}
   });
 
   t.notOk(result.errors, 'no errors');
-  t.deepEqual(result.data, { parent: { someOtherParentType: { sopt: 'some other parent type value', child: { childField: 'Child Field', anotherChildField: 'Another Child Field', addedField: 'Added from Parent'}}}}, 'complex delegation result resolved successfully');
+  t.deepEqual(result.data, { b: { compositeB: { compositeBField: 'composite b field', a: { aField: 'a field', anotherAField: 'another a field', addedField: 'added field'}}}}, 'complex delegation result resolved successfully');
   t.end();
 });
 
@@ -639,6 +639,50 @@ Test('delegateToComponent with errors', async (t) => {
   t.ok(errors && errors.length > 0, 'got error');
   t.end();
 });
+
+Test('delegateToComponent - return type is not nullable and error occurs', async (t) => {
+  const component = new GraphQLComponent({
+    imports: [
+      new GraphQLComponent({
+        types: `
+          type Test {
+            value: Boolean
+          }
+          type Query {
+            test: Test!
+          }
+        `,
+        resolvers: {
+          Query: {
+            test() {
+              throw new Error('some error');
+            }
+          }
+        }
+      })
+    ]
+  });
+
+  const document = gql`
+    query { 
+      test {
+        value
+      }
+    }`;
+
+  const { data, errors } = await graphql.execute({
+    document,
+    schema: component.schema,
+    rootValue: undefined,
+    contextValue: {}
+  });
+
+  t.equal(data, null, 'data is null');
+  t.equal(errors.length, 1, '1 error returned');
+  t.equal(errors[0].message, 'some error', 'error message is error from resolver that threw');
+
+  t.end();
+})
 
 Test('delegateToComponent - return type is abstract (__typename not requested)', async (t) => {
   let resolveTypeCallCount = 0;
@@ -779,7 +823,7 @@ Test('delegateToComponent - return type is abstract (__typename requested)', asy
   t.end();
 });
 
-Test('delegateToComponent - arg passed to delegated operation', async (t) => {
+Test('delegateToComponent - calling resolver args are passed to primitive component (reviews) field', async (t) => {
   const reviews = new GraphQLComponent({
     types: `
       type Review {

--- a/lib/delegate/__tests__.js
+++ b/lib/delegate/__tests__.js
@@ -3,7 +3,7 @@ const gql = require('graphql-tag');
 const graphql = require('graphql');
 const GraphQLComponent = require('../');
 
-Test('integration - automatic child root resolver proxying via delegateToComponent', async (t) => {
+Test('integration - automatic proxy to child root resolver from parent via delegateToComponent', async (t) => {
 
   t.plan(1);
 
@@ -41,10 +41,7 @@ Test('integration - automatic child root resolver proxying via delegateToCompone
   t.equal(data.test.value, true, 'resolved');
 });
 
-Test('delegateToComponent from root type', async (t) => {
-
-  t.plan(3);
-
+Test('delegateToComponent from root type resolver to child with same name and no subpath', async (t) => {
   const childComponent = new GraphQLComponent({
     types: `
       type Child {
@@ -52,12 +49,12 @@ Test('delegateToComponent from root type', async (t) => {
         anotherChildField: String
       }
       type Query {
-        childById: Child
+        child: Child
       }
     `,
     resolvers: {
       Query: {
-        childById() {
+        child() {
           return {
             childField: 'Child Field',
             anotherChildField: 'Another Child Field'
@@ -69,31 +66,103 @@ Test('delegateToComponent from root type', async (t) => {
 
   const component = new GraphQLComponent({
     types: `
-      type Parent {
-        child: Child
-      }
       type Child {
         addedField: String
       }
       type Query {
-        parent: Parent
+        child: Child
       }
     `,
     resolvers: {
       Query: {
-        parent: async function (_, args, context, info) {
-          const child = await GraphQLComponent.delegateToComponent(childComponent, {
-            fieldMap: {
-              child: 'childById'
-            },
-            subPath: 'child',
+        child: async function (_, _args, context, info) {
+          return GraphQLComponent.delegateToComponent(childComponent, {
             contextValue: context,
             info
           });
+        }
+      },
+      Child: {
+        addedField() {
+          return 'Added from Parent'
+        }
+      }
+    },
+    imports: [
+      childComponent
+    ]
+  });
 
+  const document = gql`
+    query { 
+      parent1: child {
+        childField
+        addedField
+      }
+        
+      parent2: child {
+        anotherChildField
+        addedField
+      }
+    }
+  `;
+
+  const result = await graphql.execute({
+    document,
+    schema: component.schema,
+    rootValue: undefined,
+    contextValue: {}
+  });
+
+  t.ok(!result.errors, 'no errors');
+  
+  const { parent1, parent2 } = result.data;
+
+  t.deepEqual(parent1, { childField: 'Child Field', addedField: 'Added from Parent' }, 'received correct first result');
+  t.deepEqual(parent2, { anotherChildField: 'Another Child Field', addedField: 'Added from Parent' }, 'received correct second result');
+  t.end();
+});
+
+Test('delegateToComponent from root type resolver to child with different name and no subpath', async (t) => {
+  const childComponent = new GraphQLComponent({
+    types: `
+      type Child {
+        childField: String
+        anotherChildField: String
+      }
+      type Query {
+        child: Child
+      }
+    `,
+    resolvers: {
+      Query: {
+        child() {
           return {
-            child
-          };
+            childField: 'Child Field',
+            anotherChildField: 'Another Child Field'
+          }
+        }
+      }
+    }
+  });
+
+  const component = new GraphQLComponent({
+    types: `
+      type Child {
+        addedField: String
+      }
+      type Query {
+        parent: Child
+      }
+    `,
+    resolvers: {
+      Query: {
+        parent: async function (_, _args, context, info) {
+          return GraphQLComponent.delegateToComponent(childComponent, {
+            targetRootField: 'child',
+            contextValue: context,
+            info
+          });
         }
       },
       Child: {
@@ -110,18 +179,16 @@ Test('delegateToComponent from root type', async (t) => {
   const document = gql`
     query { 
       parent1: parent {
-        child {
-          childField
-          addedField
-        }
+        childField
+        addedField
       }
+        
       parent2: parent {
-        child {
-          anotherChildField
-          addedField
-        }
+        anotherChildField
+        addedField
       }
-    }`;
+    }
+  `;
 
   const result = await graphql.execute({
     document,
@@ -134,14 +201,112 @@ Test('delegateToComponent from root type', async (t) => {
   
   const { parent1, parent2 } = result.data;
 
-  t.deepEqual(parent1, { child: { childField: 'Child Field', addedField: 'Added from Parent' }}, 'received correct first result');
-  t.deepEqual(parent2, { child: { anotherChildField: 'Another Child Field', addedField: 'Added from Parent' }}, 'received correct second result');
+  t.deepEqual(parent1, { childField: 'Child Field', addedField: 'Added from Parent' }, 'received correct first result');
+  t.deepEqual(parent2, { anotherChildField: 'Another Child Field', addedField: 'Added from Parent' }, 'received correct second result');
+  t.end();
 });
 
-Test('delegateToComponent from type resolver', async (t) => {
+Test('delegateToComponent from root type resolver to child with different name and sub path', async (t) => {
+  const childComponent = new GraphQLComponent({
+    types: `
+      type Child {
+        childField: String
+        anotherChildField: String
+      }
+      type Query {
+        child: Child
+      }
+    `,
+    resolvers: {
+      Query: {
+        child(_root, _args, _context, info) {
+          const selections = info.fieldNodes[0].selectionSet.selections.map((selectionNode) => { return selectionNode.name.value});
+          t.equals(selections.indexOf('parentField'), -1, 'parent field not in sub path not included in child selection set');
+          return {
+            childField: 'Child Field',
+            anotherChildField: 'Another Child Field'
+          }
+        }
+      }
+    }
+  });
 
-  t.plan(3);
+  const component = new GraphQLComponent({
+    types: `
+      type Query {
+        parent: Parent
+      }
+      type Child {
+        addedField: String
+      }
+      type Parent {
+        parentField: String
+        child: Child
+      }
+    `,
+    resolvers: {
+      Query: {
+        parent: async function (_, _args, context, info) {
+          const child = GraphQLComponent.delegateToComponent(childComponent, {
+            targetRootField: 'child',
+            subPath: 'child',
+            contextValue: context,
+            info
+          });
+          return {
+            parentField: 'parentField',
+            child
+          }
+        }
+      },
+      Child: {
+        addedField() {
+          return 'Added from Parent'
+        }
+      }
+    },
+    imports: [
+      childComponent
+    ]
+  });
 
+  const document = gql`
+    query { 
+      parent1: parent {
+        parentField
+        child { 
+          childField
+          addedField
+        }
+      }
+        
+      parent2: parent {
+        parentField
+        child {
+          anotherChildField
+          addedField
+        }
+      }
+    }
+  `;
+
+  const result = await graphql.execute({
+    document,
+    schema: component.schema,
+    rootValue: undefined,
+    contextValue: {}
+  });
+
+  t.notOk(result.errors, 'no errors');
+  
+  const { parent1, parent2 } = result.data;
+
+  t.deepEqual(parent1, { parentField: 'parentField', child: { childField: 'Child Field', addedField: 'Added from Parent' }}, 'received correct first result');
+  t.deepEqual(parent2, { parentField: 'parentField', child: {anotherChildField: 'Another Child Field', addedField: 'Added from Parent' }}, 'received correct second result');
+  t.end();
+});
+
+Test('delegateToComponent from non-root type resolver to child with same name and no sub path', async (t) => {
   const childComponent = new GraphQLComponent({
     types: `
       type Child {
@@ -230,12 +395,199 @@ Test('delegateToComponent from type resolver', async (t) => {
 
   t.deepEqual(parent1, { child: { childField: 'Child Field', addedField: 'Added from Parent', }}, 'received correct first result');
   t.deepEqual(parent2, { child: { anotherChildField: 'Another Child Field', addedField: 'Added from Parent' }}, 'received correct second result');
+  t.end();
+});
+
+Test('delegateToComponent from non-root type resolver to child with different name and no sub path', async (t) => {
+  const childComponent = new GraphQLComponent({
+    types: `
+      type Child {
+        childField: String
+        anotherChildField: String
+      }
+      type Query {
+        child: Child
+      }
+    `,
+    resolvers: {
+      Query: {
+        child() {
+          return {
+            childField: 'Child Field',
+            anotherChildField: 'Another Child Field'
+          }
+        }
+      }
+    }
+  });
+
+  const component = new GraphQLComponent({
+    types: `
+      type Parent {
+        someParentField: Child
+      }
+      type Child {
+        addedField: String
+      }
+      type Query {
+        parent: Parent
+      }
+    `,
+    resolvers: {
+      Query: {
+        parent: async function () {
+          return {};
+        }
+      },
+      Parent: {
+        someParentField(_, args, context, info) {
+          return GraphQLComponent.delegateToComponent(childComponent, {
+            targetRootField: 'child',
+            contextValue: context,
+            info
+          });
+        }
+      },
+      Child: {
+        addedField() {
+          return 'Added from Parent'
+        }
+      }
+    },
+    imports: [
+      childComponent
+    ]
+  });
+
+  const document = gql`
+    query { 
+      parent1: parent {
+        someParentField {
+          childField
+          addedField
+        }
+      }
+      parent2: parent {
+        someParentField {
+          anotherChildField
+          addedField
+        }
+      }
+    }`;
+
+  const result = await graphql.execute({
+    document,
+    schema: component.schema,
+    rootValue: undefined,
+    contextValue: {}
+  });
+
+  t.ok(!result.errors, 'no errors');
+  
+  const { parent1, parent2 } = result.data;
+
+  t.deepEqual(parent1, { someParentField: { childField: 'Child Field', addedField: 'Added from Parent', }}, 'received correct first result');
+  t.deepEqual(parent2, { someParentField: { anotherChildField: 'Another Child Field', addedField: 'Added from Parent' }}, 'received correct second result');
+  t.end();
+});
+
+Test('delegateToComponent from non-root type resolver to child with different name and sub path', async (t) => {
+  const childComponent = new GraphQLComponent({
+    types: `
+      type Child {
+        childField: String
+        anotherChildField: String
+      }
+      type Query {
+        child: Child
+      }
+    `,
+    resolvers: {
+      Query: {
+        child(_root, _args, _context, info) {
+          const selections = info.fieldNodes[0].selectionSet.selections.map((selectionNode) => { return selectionNode.name.value});
+          t.equals(selections.indexOf('sopt'), -1, 'parent field not in sub path not included in child selection set');
+          return {
+            childField: 'Child Field',
+            anotherChildField: 'Another Child Field'
+          }
+        }
+      }
+    }
+  });
+
+  const component = new GraphQLComponent({
+    types: `
+      type Query {
+        parent: Parent
+      }
+      type Child {
+        addedField: String
+      }
+      type SomeOtherParentType {
+        sopt: String
+        child: Child
+      }
+      type Parent {
+        someOtherParentType: SomeOtherParentType
+      }
+    `,
+    resolvers: {
+      Query: {
+        parent: async function (){
+          return {}
+        }
+      },
+      Parent: {
+        someOtherParentType(root, args, context, info) {
+          const child = GraphQLComponent.delegateToComponent(childComponent, {
+            targetRootField: 'child',
+            subPath: 'child',
+            contextValue: context,
+            info
+          });
+          return { sopt: 'some other parent type value', child }
+        }
+      },
+      Child: {
+        addedField() {
+          return 'Added from Parent'
+        }
+      }
+    },
+    imports: [
+      childComponent
+    ]
+  });
+
+  const document = gql`
+    query {
+      parent {
+        someOtherParentType {
+          sopt
+          child {
+            childField
+            anotherChildField
+            addedField
+          }
+        }
+      }
+    }
+  `;
+
+  const result = await graphql.execute({
+    document,
+    schema: component.schema,
+    rootValue: undefined,
+    contextValue: {}
+  });
+
+  t.notOk(result.errors, 'no errors');
+  t.deepEqual(result.data, { parent: { someOtherParentType: { sopt: 'some other parent type value', child: { childField: 'Child Field', anotherChildField: 'Another Child Field', addedField: 'Added from Parent'}}}}, 'complex delegation result resolved successfully');
+  t.end();
 });
 
 Test('delegateToComponent with errors', async (t) => {
-
-  t.plan(3);
-
   const component = new GraphQLComponent({
     imports: [
       new GraphQLComponent({
@@ -285,9 +637,10 @@ Test('delegateToComponent with errors', async (t) => {
   t.equal(data.foo.value, true, 'resolved alias 1');
   t.equal(data.bar.value, true, 'resolved alias 2');
   t.ok(errors && errors.length > 0, 'got error');
+  t.end();
 });
 
-Test('delegateToComponent - return type is abstract', async (t) => {
+Test('delegateToComponent - return type is abstract (__typename not requested)', async (t) => {
   let resolveTypeCallCount = 0;
   const child = new GraphQLComponent({
     types: `
@@ -350,8 +703,146 @@ Test('delegateToComponent - return type is abstract', async (t) => {
     contextValue: {}
   });
 
-  t.deepEquals(result.data.things, [{ id: '1', name: 'Joe Smith', __typename: 'Person' }], 'interface type resolved');
+  t.deepEquals(result.data.things, [{ id: '1', name: 'Joe Smith' }], 'interface type resolved');
   t.equals(resolveTypeCallCount, 1, '__resolveType called in child once per item in list');
   t.notOk(result.errors, 'no errors');
+  t.end();
+});
+
+Test('delegateToComponent - return type is abstract (__typename requested)', async (t) => {
+  let resolveTypeCallCount = 0;
+  const child = new GraphQLComponent({
+    types: `
+      type Query {
+        things: [Thing]
+      }
+      interface Thing {
+        id: ID
+      }
+      type Person implements Thing {
+        id: ID
+        name: String
+      }
+      type Animal implements Thing {
+        id: ID
+        someField: Int
+      }
+    `,
+    resolvers: {
+      Query: {
+        things() {
+          return [
+            {
+              id: '1',
+              name: 'Joe Smith'
+            }
+          ]
+        }
+      },
+      Thing: {
+        __resolveType(parent) {
+          resolveTypeCallCount = resolveTypeCallCount + 1;
+          if (parent.name) {
+            return 'Person';
+          }
+          return 'Animal';
+        }
+      }
+    }
+  });
+
+  const parent = new GraphQLComponent({
+    imports: [
+      child
+    ]
+  });
+
+  const result = await graphql.execute({
+    document: gql`
+      query {
+        things {
+          id
+          ... on Person {
+            name
+          },
+          __typename
+        }
+      }
+    `,
+    schema: parent.schema,
+    contextValue: {}
+  });
+
+  t.deepEquals(result.data.things, [{ id: '1', name: 'Joe Smith', __typename: 'Person' }], 'interface type resolved (including requested __typename)');
+  t.equals(resolveTypeCallCount, 1, '__resolveType called in child once per item in list');
+  t.notOk(result.errors, 'no errors');
+  t.end();
+});
+
+Test('delegateToComponent - arg passed to delegated operation', async (t) => {
+  const reviews = new GraphQLComponent({
+    types: `
+      type Review {
+        id: ID
+        content: String
+      }
+
+      type Query {
+        reviewsByPropertyId(id: ID): [Review]
+      }
+    `,
+    resolvers: {
+      Query: {
+        reviewsByPropertyId(_root, args) {
+          t.equals(args.id, '1', 'property id from parent resolver passed to child');
+          return [{ id: 'revid', content: 'some review content'}];
+        }
+      }
+    }
+  });
+
+  const property = new GraphQLComponent({
+    types: `
+      type Property {
+        id: ID
+        reviews: [Review]
+      }
+
+      type Query {
+        propertyById(id: ID): Property
+      }
+    `,
+    resolvers: {
+      Query: {
+        async propertyById(root, args, context, info) {
+          const revs = await GraphQLComponent.delegateToComponent(reviews, {
+            targetRootField: 'reviewsByPropertyId',
+            subPath: 'reviews',
+            info,
+            contextValue: context
+          })
+          return { id: args.id, reviews: revs }
+        }
+      }
+    },
+    imports: [reviews]
+  });
+
+  const result = await graphql.execute({
+    document: gql`
+      query {
+        propertyById(id: 1) {
+          id
+          reviews {
+            id
+            content
+          }
+        }
+      }
+    `,
+    schema: property.schema,
+    contextValue: {}
+  });
+  t.deepEqual(result.data, { propertyById: { id: '1', reviews: [{ id: 'revid', content: 'some review content'}]}}, 'propery reviews successfully resolved');
   t.end();
 });

--- a/lib/delegate/index.js
+++ b/lib/delegate/index.js
@@ -76,7 +76,7 @@ const createSubOperationDocument = function (targetRootField, subPath, info) {
     operation: info.operation.operation,
     selectionSet: { kind: Kind.SELECTION_SET, selections: [targetRootFieldNode]},
     variableDefinitions: info.operation.variableDefinitions
-  }
+  };
 
   const definitions = [operationDefinition]
   for (const [, fragmentDefinition] of Object.entries(info.fragments)) {
@@ -85,7 +85,7 @@ const createSubOperationDocument = function (targetRootField, subPath, info) {
   return {
     kind: Kind.DOCUMENT,
     definitions
-  }
+  };
 }
 
 /**
@@ -129,13 +129,18 @@ const delegateToComponent = async function (component, options) {
 
   debug(`delegating ${print(document)} to ${component.name}`);
 
-  const { data = {}, errors = [] } = await execute({
+  let { data, errors = [] } = await execute({
     document, 
     schema: component.schema, 
     rootValue: info.rootValue, 
     contextValue, 
     variableValues: info.variableValues
   });
+
+  // data can be completely null and destructuring defaults only apply to undefined
+  if (!data) {
+    data = {};
+  }
   
   if (errors.length > 0) {
     for (const error of errors) {

--- a/lib/delegate/index.js
+++ b/lib/delegate/index.js
@@ -1,0 +1,134 @@
+const { Kind, execute, isAbstractType, getNamedType} = require('graphql');
+const deepSet = require('lodash.set');
+
+/**
+ * helper function to extract the so-far traversed path from an info object 
+ * passed to resolvers
+ * @param {Object} info - the info object passed to resolvers
+ * @returns {Array<String>} - the derived path from the input info object
+ */
+const buildPathFromInfo = function (info) {
+  const path = [];
+  let current = info.path;
+
+  do {
+    path.unshift(current.key);
+    current = current.prev;
+  }
+  while (current !== undefined);
+
+  return path;
+};
+
+const getSelectionSetForPath = function (fieldPath, fieldMap, selectionSet) {
+  const getSelection = function (name, selections) {
+    for (const selection of selections) {
+      if (selection.name.value === name || selection.alias.value === name) {
+        return selection;
+      }
+    }
+  };
+
+  let path = fieldPath.shift();
+  let current = getSelection(path, selectionSet.selections);
+
+  while (fieldPath.length > 0) {
+    path = fieldPath.shift();
+    current = current && getSelection(path, current.selectionSet.selections);
+  }
+
+  return current ? {
+    kind: Kind.FIELD,
+    alias: current.alias,
+    name: {
+      name: Kind.NAME,
+      value: fieldMap[current.name.value] || current.name.value
+    },
+    arguments: current.arguments,
+    directives: current.directives,
+    selectionSet: current.selectionSet
+  } : undefined;
+};
+
+const createSubOperationForField = function (component, fieldPath, fieldMap, info) {
+  const operation = info.operation;
+  const fragments = info.fragments;
+
+  // TODO: use this to see if a field exists on underlying component schema
+  // const rootType = component.schema.getType(info.parentType.name);
+  // const rootFields = rootType.getFields();
+  // const returnType = rootFields[fieldPath[fieldPath.length - 1]].type;
+  // const returnTypeFields = returnType.getFields();
+
+  const definitions = [];
+
+  if (fragments) {
+    for (const [, fragmentDefinition] of Object.entries(fragments)) {
+      definitions.push(fragmentDefinition);
+    }
+  }
+
+  const selections = getSelectionSetForPath([...fieldPath], fieldMap, operation.selectionSet);
+
+  //Add __typename request for usage in __resolveType
+  if (selections && selections.selectionSet) {
+    if (isAbstractType(getNamedType(info.returnType))) {
+      selections.selectionSet.selections.push({
+        kind: Kind.FIELD,
+        name: {
+          kind: Kind.NAME,
+          value: '__typename'
+        }
+      });
+    }
+  }
+
+  definitions.push({
+    kind: Kind.OPERATION_DEFINITION,
+    operation: operation.operation,
+    variableDefinitions: operation.variableDefinitions,
+    selectionSet: {
+      kind: Kind.SELECTION_SET,
+      selections: [
+        selections
+      ]
+    }
+  });
+
+  return {
+    kind: Kind.DOCUMENT,
+    definitions
+  };
+};
+
+// Eventually accept an argument to map fields for sub-query?
+const delegateToComponent = async function (component, { fieldMap = {}, subPath, contextValue, info }) {
+  const rootPath = buildPathFromInfo(info);
+  const fieldPath = subPath !== undefined ? [...rootPath, ...subPath.split('.')] : rootPath;
+
+  const { rootValue, variableValues } = info;
+  
+  const document = createSubOperationForField(component, fieldPath, fieldMap, info);
+  
+  const { data = {}, errors = [] } = await execute({ document, schema: component.schema, rootValue, contextValue, variableValues });
+  
+  if (errors.length > 0) {
+    for (const error of errors) {
+      deepSet(data, error.path, error);
+    }
+  }
+
+  let result = {};
+
+  //do not count current field resolver in path since that will exist in data result
+  deepSet(result, rootPath.length > 1 ? rootPath.slice(0, rootPath.length - 1) : rootPath, data);
+  
+  while (fieldPath.length > 0) {
+    let path = fieldPath.shift();
+    result = result[fieldMap[path] || path];
+  }
+  
+  return result;
+};
+
+module.exports = { delegateToComponent };

--- a/lib/delegate/index.js
+++ b/lib/delegate/index.js
@@ -1,116 +1,141 @@
-const { Kind, execute, isAbstractType, getNamedType} = require('graphql');
+const { Kind, execute, isAbstractType, getNamedType, print } = require('graphql');
 const deepSet = require('lodash.set');
+const debug = require('debug')('graphql-component:delegate');
 
 /**
- * helper function to extract the so-far traversed path from an info object 
- * passed to resolvers
- * @param {Object} info - the info object passed to resolvers
- * @returns {Array<String>} - the derived path from the input info object
+ * extracts the Array<SelectionNode> at the given path
+ * @param {String} path - dot seperated string defining the path to the sub 
+ * selection
+ * @param {Array<SelectionNode>} selections - an array of SelectionNode objects
+ * @returns {Array<SelectionNode>} - an array of SelectionNode objects
+ * representing the sub selection set at the given sub path
  */
-const buildPathFromInfo = function (info) {
-  const path = [];
-  let current = info.path;
-
-  do {
-    path.unshift(current.key);
-    current = current.prev;
+const getSelectionsForSubPath = function(path, selections) {
+  if (!path) {
+    return selections;
   }
-  while (current !== undefined);
-
-  return path;
-};
-
-const getSelectionSetForPath = function (fieldPath, fieldMap, selectionSet) {
-  const getSelection = function (name, selections) {
+  const parsedPath = path.split('.');
+  const getSelections = function (name, selections) {
     for (const selection of selections) {
-      if (selection.name.value === name || selection.alias.value === name) {
-        return selection;
+      if ((selection.name && selection.name.value === name) || (selection.alias && selection.alias.value === name)) {
+        return selection.selectionSet && selection.selectionSet.selections;
       }
     }
   };
 
-  let path = fieldPath.shift();
-  let current = getSelection(path, selectionSet.selections);
-
-  while (fieldPath.length > 0) {
-    path = fieldPath.shift();
-    current = current && getSelection(path, current.selectionSet.selections);
+  let pathSegment = parsedPath.shift();
+  let subSelections = getSelections(pathSegment, selections);
+  while (parsedPath.length > 0 && !subSelections) {
+    pathSegment = parsedPath.shift();
+    subSelections = getSelections(pathSegment, subSelections);
   }
 
-  return current ? {
+  if (subSelections) {
+    return subSelections;
+  }
+  return selections;
+}
+
+const createSubOperationDocument = function (targetRootField, subPath, info) {
+  
+  // default the selection set we delegate to the complete selection
+  // set starting at the calling resolver
+  let selections = info.fieldNodes.reduce((acc, fieldNode) => {
+    if (fieldNode.selectionSet && fieldNode.selectionSet.selections) {
+      return acc.concat(fieldNode.selectionSet.selections)
+    }
+  }, []);
+
+  // extract the selection set at the specified subPath
+  selections = getSelectionsForSubPath(subPath, selections);
+
+  // add in a top level __typename selection if the calling resolver's return type is Abstract
+  if (isAbstractType(getNamedType(info.returnType))) {
+    selections.push({
+      kind: Kind.FIELD,
+      name: { kind: Kind.NAME, value: '__typename' }
+    });
+  }
+
+  // extract the arguments from the calling resolver
+  let newArgs = info.fieldNodes.reduce((acc, fieldNode) => {
+    if (fieldNode.arguments) {
+      return acc.concat(fieldNode.arguments);
+    }
+  }, []);
+
+  const targetRootFieldNode = {
     kind: Kind.FIELD,
-    alias: current.alias,
-    name: {
-      name: Kind.NAME,
-      value: fieldMap[current.name.value] || current.name.value
-    },
-    arguments: current.arguments,
-    directives: current.directives,
-    selectionSet: current.selectionSet
-  } : undefined;
-};
+    arguments: newArgs,
+    name: { kind: Kind.NAME, value: targetRootField },
+    selectionSet: { kind: Kind.SELECTION_SET, selections }
+  };
 
-const createSubOperationForField = function (component, fieldPath, fieldMap, info) {
-  const operation = info.operation;
-  const fragments = info.fragments;
-
-  // TODO: use this to see if a field exists on underlying component schema
-  // const rootType = component.schema.getType(info.parentType.name);
-  // const rootFields = rootType.getFields();
-  // const returnType = rootFields[fieldPath[fieldPath.length - 1]].type;
-  // const returnTypeFields = returnType.getFields();
-
-  const definitions = [];
-
-  if (fragments) {
-    for (const [, fragmentDefinition] of Object.entries(fragments)) {
-      definitions.push(fragmentDefinition);
-    }
-  }
-
-  const selections = getSelectionSetForPath([...fieldPath], fieldMap, operation.selectionSet);
-
-  //Add __typename request for usage in __resolveType
-  if (selections && selections.selectionSet) {
-    if (isAbstractType(getNamedType(info.returnType))) {
-      selections.selectionSet.selections.push({
-        kind: Kind.FIELD,
-        name: {
-          kind: Kind.NAME,
-          value: '__typename'
-        }
-      });
-    }
-  }
-
-  definitions.push({
+  const operationDefinition = {
     kind: Kind.OPERATION_DEFINITION,
-    operation: operation.operation,
-    variableDefinitions: operation.variableDefinitions,
-    selectionSet: {
-      kind: Kind.SELECTION_SET,
-      selections: [
-        selections
-      ]
-    }
-  });
+    operation: info.operation.operation,
+    selectionSet: { kind: Kind.SELECTION_SET, selections: [targetRootFieldNode]},
+    variableDefinitions: info.operation.variableDefinitions
+  }
 
+  const definitions = [operationDefinition]
+  for (const [, fragmentDefinition] of Object.entries(info.fragments)) {
+    definitions.push(fragmentDefinition);
+  }
   return {
     kind: Kind.DOCUMENT,
     definitions
-  };
-};
+  }
+}
 
-// Eventually accept an argument to map fields for sub-query?
-const delegateToComponent = async function (component, { fieldMap = {}, subPath, contextValue, info }) {
-  const rootPath = buildPathFromInfo(info);
-  const fieldPath = subPath !== undefined ? [...rootPath, ...subPath.split('.')] : rootPath;
+/**
+ * executes (delegates) a graphql operation on the input component's schema
+ * @param {GraphQLComponent} component - the component to delegate execution to
+ * @param {object} options - an options object to customize the delegated 
+ * operation
+ * @param {GraphQLResolveInfo} options.info - the info object from the calling resolver
+ * @param {object} options.contextValue - the context object from the calling 
+ * resolver
+ * @param {string} [options.targetRootField] - the name of the root type field 
+ * the delegated operation will execute. Defaults to the field name of the 
+ * calling resolver
+ * @param {string} [options.subPath] - a dot separated string to limit the 
+ * delegated selection set to a given path in the calling resolver's return type
+ * @returns the result of the delegated operation to the targetRootField with
+ * any errors merged into the result at their given path
+ */
+const delegateToComponent = async function (component, options) { 
+  let {
+    subPath,
+    contextValue,
+    info,
+    targetRootField
+  } = options;
 
-  const { rootValue, variableValues } = info;
-  
-  const document = createSubOperationForField(component, fieldPath, fieldMap, info);
-  
-  const { data = {}, errors = [] } = await execute({ document, schema: component.schema, rootValue, contextValue, variableValues });
+  if (!contextValue) {
+    throw new Error('delegateToComponent requires the contextValue from the calling resolver');
+  }
+
+  if (!info) {
+    throw new Error('delegateToComponent requires the info object from the calling resolver');
+  }
+
+  // default the target root field to be the name of the calling resolver
+  if (!targetRootField) {
+    targetRootField = info.fieldName;
+  }
+
+  const document = createSubOperationDocument(targetRootField, subPath, info);
+
+  debug(`delegating ${print(document)} to ${component.name}`);
+
+  const { data = {}, errors = [] } = await execute({
+    document, 
+    schema: component.schema, 
+    rootValue: info.rootValue, 
+    contextValue, 
+    variableValues: info.variableValues
+  });
   
   if (errors.length > 0) {
     for (const error of errors) {
@@ -118,17 +143,7 @@ const delegateToComponent = async function (component, { fieldMap = {}, subPath,
     }
   }
 
-  let result = {};
-
-  //do not count current field resolver in path since that will exist in data result
-  deepSet(result, rootPath.length > 1 ? rootPath.slice(0, rootPath.length - 1) : rootPath, data);
-  
-  while (fieldPath.length > 0) {
-    let path = fieldPath.shift();
-    result = result[fieldMap[path] || path];
-  }
-  
-  return result;
+  return data[targetRootField];
 };
 
 module.exports = { delegateToComponent };

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,10 +6,11 @@ const { mergeResolvers, mergeTypeDefs } = require('@graphql-tools/merge');
 const { makeExecutableSchema } = require('@graphql-tools/schema');
 const { addMocksToSchema } = require('@graphql-tools/mock');
 const { SchemaDirectiveVisitor } = require('@graphql-tools/utils');
-const { wrapResolvers, delegateToComponent } = require('./resolvers');
+const { wrapResolvers } = require('./resolvers');
 const { buildDependencyTree } = require('./imports');
 const { wrapContext, createContext } = require('./context');
 const { createDataSourceInjection } = require('./datasource');
+const { delegateToComponent } = require('./delegate');
 const cuid = require('cuid');
 
 const debug = require('debug')('graphql-component:schema');

--- a/lib/resolvers/__tests__.js
+++ b/lib/resolvers/__tests__.js
@@ -453,7 +453,6 @@ Test('importResolvers()', (t) => {
 
     const importedResolvers = importResolvers(component);
     st.ok(importedResolvers.Query.thing.__isProxy, 'Query.thing is a proxy');
-    st.ok(importedResolvers.Thing.__resolveType, '__resolveType was pulled up');
     st.end();
   });
 })

--- a/lib/resolvers/__tests__.js
+++ b/lib/resolvers/__tests__.js
@@ -414,47 +414,6 @@ Test('importResolvers()', (t) => {
     st.notOk(importedResolvers.SomeType, 'non-root type (SomeType) is not imported')
     st.end();
   });
-
-  t.test(`import component's resolvers that contain an abstract type`, (st) => {
-    const component = new GraphQLComponent({
-      types: `
-        type Query {
-          thing: Thing
-        }
-        interface Thing {
-          id: ID
-        }
-        type A implements Thing {
-          id: ID
-          fieldForA: String
-        }
-        type B implements Thing {
-          id: ID
-          fieldForB: String
-        }
-      `,
-      resolvers: {
-        Query: {
-          thing() {
-            return { id: '1', fieldForA: 'a', fieldForB: 'b'};
-          }
-        },
-        Thing: {
-          __resolveType(thing) {
-            if (thing.fieldForA) {
-              return 'A';
-            } else if (thing.fieldForB) {
-              return 'B';
-            }
-          }
-        }
-      }
-    });
-
-    const importedResolvers = importResolvers(component);
-    st.ok(importedResolvers.Query.thing.__isProxy, 'Query.thing is a proxy');
-    st.end();
-  });
 })
 
 

--- a/lib/resolvers/index.js
+++ b/lib/resolvers/index.js
@@ -138,10 +138,7 @@ const wrapResolvers = function (bind, resolvers = {}) {
 const createProxyResolver = function (component, rootType, fieldName) {
   const proxyResolver = async function (_, args, contextValue, info) {
     debug(`delegating ${rootType}.${fieldName} to ${component.name}`);
-    
-    const result = await delegateToComponent(component, { contextValue, info });
-    
-    return result[info.path.key];
+    return delegateToComponent(component, { contextValue, info });
   };
 
   proxyResolver.__isProxy = true;
@@ -170,7 +167,6 @@ const importResolvers = function (component, excludes) {
 
   const resolvers = {};
   for (const [type, fieldResolvers] of iterateRootTypeResolvers()) {
-      // create a proxy resolver for root type fields
     if (resolvers[type] === undefined) {
       resolvers[type] = {};
     }

--- a/lib/resolvers/index.js
+++ b/lib/resolvers/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const debug = require('debug')('graphql-component:resolver');
-const { GraphQLScalarType, Kind, execute } = require('graphql');
+const { GraphQLScalarType, Kind, execute, isAbstractType, getNamedType } = require('graphql');
 const deepSet = require('lodash.set');
 
 /**
@@ -143,7 +143,7 @@ const buildPathFromInfo = function (info) {
   return path;
 };
 
-const getSelectionSetForPath = function (fieldPath, selectionSet) {
+const getSelectionSetForPath = function (fieldPath, fieldMap, selectionSet) {
   const getSelection = function (name, selections) {
     for (const selection of selections) {
       if (selection.name.value === name || selection.alias.value === name) {
@@ -160,10 +160,20 @@ const getSelectionSetForPath = function (fieldPath, selectionSet) {
     current = current && getSelection(path, current.selectionSet.selections);
   }
 
-  return current;
+  return current ? {
+    kind: Kind.FIELD,
+    alias: current.alias,
+    name: {
+      name: Kind.NAME,
+      value: fieldMap[current.name.value] || current.name.value
+    },
+    arguments: current.arguments,
+    directives: current.directives,
+    selectionSet: current.selectionSet
+  } : undefined;
 };
 
-const createSubOperationForField = function (component, fieldPath, info) {
+const createSubOperationForField = function (component, fieldPath, fieldMap, info) {
   const operation = info.operation;
   const fragments = info.fragments;
 
@@ -181,17 +191,19 @@ const createSubOperationForField = function (component, fieldPath, info) {
     }
   }
 
-  const selections = getSelectionSetForPath([...fieldPath], operation.selectionSet);
+  const selections = getSelectionSetForPath([...fieldPath], fieldMap, operation.selectionSet);
 
   //Add __typename request for usage in __resolveType
   if (selections && selections.selectionSet) {
-    selections.selectionSet.selections.push({
-      kind: Kind.FIELD,
-      name: {
-        kind: Kind.NAME,
-        value: '__typename'
-      }
-    });
+    if (isAbstractType(getNamedType(info.returnType))) {
+      selections.selectionSet.selections.push({
+        kind: Kind.FIELD,
+        name: {
+          kind: Kind.NAME,
+          value: '__typename'
+        }
+      });
+    }
   }
 
   definitions.push({
@@ -213,13 +225,13 @@ const createSubOperationForField = function (component, fieldPath, info) {
 };
 
 // Eventually accept an argument to map fields for sub-query?
-const delegateToComponent = async function (component, { subPath, contextValue, info }) {
+const delegateToComponent = async function (component, { fieldMap = {}, subPath, contextValue, info }) {
   const rootPath = buildPathFromInfo(info);
   const fieldPath = subPath !== undefined ? [...rootPath, ...subPath.split('.')] : rootPath;
 
   const { rootValue, variableValues } = info;
   
-  const document = createSubOperationForField(component, fieldPath, info);
+  const document = createSubOperationForField(component, fieldPath, fieldMap, info);
   
   const { data = {}, errors = [] } = await execute({ document, schema: component.schema, rootValue, contextValue, variableValues });
   
@@ -236,7 +248,7 @@ const delegateToComponent = async function (component, { subPath, contextValue, 
   
   while (fieldPath.length > 0) {
     let path = fieldPath.shift();
-    result = result[path];
+    result = result[fieldMap[path] || path];
   }
   
   return result;
@@ -295,20 +307,6 @@ const importResolvers = function (component, excludes) {
           resultingResolverMap[type] = {};
         }
         resultingResolverMap[type][field] = createProxyResolver(component, type, field);
-      } else if (field.startsWith('__')) {
-        if (resultingResolverMap[type] === undefined) {
-          resultingResolverMap[type] = {};
-        }
-        
-        // automatically create a __resolveType function at the parent level
-        // that returns the __typename of the prior resolver's result
-        if (field === '__resolveType') {
-          resultingResolverMap[type][field] = function (_) {
-            return _.__typename;
-          }
-        } else {
-          resultingResolverMap[type][field] = resolverFunc;
-        }
       }
     }
   }

--- a/lib/resolvers/index.js
+++ b/lib/resolvers/index.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const debug = require('debug')('graphql-component:resolver');
-const { GraphQLScalarType, Kind, execute, isAbstractType, getNamedType } = require('graphql');
-const deepSet = require('lodash.set');
+const { GraphQLScalarType } = require('graphql');
+const { delegateToComponent } = require('../delegate');
 
 /**
  * memoizes resolver functions such that calls of an identical resolver (args/context/path) within the same request context are avoided
@@ -125,136 +125,6 @@ const wrapResolvers = function (bind, resolvers = {}) {
 };
 
 /**
- * helper function to extract the so-far traversed path from an info object 
- * passed to resolvers
- * @param {Object} info - the info object passed to resolvers
- * @returns {Array<String>} - the derived path from the input info object
- */
-const buildPathFromInfo = function (info) {
-  const path = [];
-  let current = info.path;
-
-  do {
-    path.unshift(current.key);
-    current = current.prev;
-  }
-  while (current !== undefined);
-
-  return path;
-};
-
-const getSelectionSetForPath = function (fieldPath, fieldMap, selectionSet) {
-  const getSelection = function (name, selections) {
-    for (const selection of selections) {
-      if (selection.name.value === name || selection.alias.value === name) {
-        return selection;
-      }
-    }
-  };
-
-  let path = fieldPath.shift();
-  let current = getSelection(path, selectionSet.selections);
-
-  while (fieldPath.length > 0) {
-    path = fieldPath.shift();
-    current = current && getSelection(path, current.selectionSet.selections);
-  }
-
-  return current ? {
-    kind: Kind.FIELD,
-    alias: current.alias,
-    name: {
-      name: Kind.NAME,
-      value: fieldMap[current.name.value] || current.name.value
-    },
-    arguments: current.arguments,
-    directives: current.directives,
-    selectionSet: current.selectionSet
-  } : undefined;
-};
-
-const createSubOperationForField = function (component, fieldPath, fieldMap, info) {
-  const operation = info.operation;
-  const fragments = info.fragments;
-
-  // TODO: use this to see if a field exists on underlying component schema
-  // const rootType = component.schema.getType(info.parentType.name);
-  // const rootFields = rootType.getFields();
-  // const returnType = rootFields[fieldPath[fieldPath.length - 1]].type;
-  // const returnTypeFields = returnType.getFields();
-
-  const definitions = [];
-
-  if (fragments) {
-    for (const [, fragmentDefinition] of Object.entries(fragments)) {
-      definitions.push(fragmentDefinition);
-    }
-  }
-
-  const selections = getSelectionSetForPath([...fieldPath], fieldMap, operation.selectionSet);
-
-  //Add __typename request for usage in __resolveType
-  if (selections && selections.selectionSet) {
-    if (isAbstractType(getNamedType(info.returnType))) {
-      selections.selectionSet.selections.push({
-        kind: Kind.FIELD,
-        name: {
-          kind: Kind.NAME,
-          value: '__typename'
-        }
-      });
-    }
-  }
-
-  definitions.push({
-    kind: Kind.OPERATION_DEFINITION,
-    operation: operation.operation,
-    variableDefinitions: operation.variableDefinitions,
-    selectionSet: {
-      kind: Kind.SELECTION_SET,
-      selections: [
-        selections
-      ]
-    }
-  });
-
-  return {
-    kind: Kind.DOCUMENT,
-    definitions
-  };
-};
-
-// Eventually accept an argument to map fields for sub-query?
-const delegateToComponent = async function (component, { fieldMap = {}, subPath, contextValue, info }) {
-  const rootPath = buildPathFromInfo(info);
-  const fieldPath = subPath !== undefined ? [...rootPath, ...subPath.split('.')] : rootPath;
-
-  const { rootValue, variableValues } = info;
-  
-  const document = createSubOperationForField(component, fieldPath, fieldMap, info);
-  
-  const { data = {}, errors = [] } = await execute({ document, schema: component.schema, rootValue, contextValue, variableValues });
-  
-  if (errors.length > 0) {
-    for (const error of errors) {
-      deepSet(data, error.path, error);
-    }
-  }
-
-  let result = {};
-
-  //do not count current field resolver in path since that will exist in data result
-  deepSet(result, rootPath.length > 1 ? rootPath.slice(0, rootPath.length - 1) : rootPath, data);
-  
-  while (fieldPath.length > 0) {
-    let path = fieldPath.shift();
-    result = result[fieldMap[path] || path];
-  }
-  
-  return result;
-};
-
-/**
  * returns a proxy function that delegates execution to the input component's 
  * schema
  * @param {Object} component - the component to delegate execution to
@@ -290,27 +160,25 @@ const createProxyResolver = function (component, rootType, fieldName) {
 const importResolvers = function (component, excludes) {
   const filteredResolvers = filterResolvers(component.resolvers, excludes);
 
-  const iterateResolvers = function* () {
+  const iterateRootTypeResolvers = function* () {
     for (const type of Object.keys(filteredResolvers)) {
-      yield [type, component.resolvers[type]];
+      if (['Query', 'Mutation', 'Subscription'].indexOf(type) > -1) {
+        yield [type, component.resolvers[type]];
+      }
     }
   };
 
-  const resultingResolverMap = {};
-
-  for (const [type, fieldResolvers] of iterateResolvers()) {
-    for (const [field, resolverFunc] of Object.entries(fieldResolvers)) {
-      // type is a root type
-      if (['Query', 'Mutation', 'Subscription'].indexOf(type) > -1) {
-        // create a proxy resolver for root type fields
-        if (resultingResolverMap[type] === undefined) {
-          resultingResolverMap[type] = {};
-        }
-        resultingResolverMap[type][field] = createProxyResolver(component, type, field);
-      }
+  const resolvers = {};
+  for (const [type, fieldResolvers] of iterateRootTypeResolvers()) {
+      // create a proxy resolver for root type fields
+    if (resolvers[type] === undefined) {
+      resolvers[type] = {};
+    }
+    for (const field of Object.keys(fieldResolvers)) {
+      resolvers[type][field] = createProxyResolver(component, type, field);
     }
   }
-  return resultingResolverMap;
+  return resolvers;
 }
 
 module.exports = { memoize, filterResolvers, wrapResolvers, createProxyResolver, importResolvers, delegateToComponent };


### PR DESCRIPTION
summary of changes:
* broke out delegateToComponent into it's own module with co-located tests (which meant moving the delegate tests from the root test file to `lib/delegate/__tests__.js`)
* added additional `component API` tests (`lib/__tests__.js`) for completeness
* modified delegateToComponent to create the sub document from info.fieldNodes:
   * this prevents modifications,  (such as adding __typename to the selection) from leaking back to the original graphql execution
   * reduces some iterations because we only need to consider the AST from the calling resolver forward (instead of starting at the root of the original document)
* add some additional undefined checks to getSelectionsForPath since a SelectionNode's alias field can be undefined if not provided
* switched out `fieldMap` with simply `targetRootField` in order for the caller to specify the root field they want to execute otherwise it defaults to the calling resolver's field name
* sub path algorithm is same as before but uses fieldNodes to traverse the tree and find the sub selection set
* further simplified the importResolvers loop now that we dont need to pull up __resolveType


### TODO
* ~document delegateToComponent in README~
* still couldn't hack adding arguments - it seems quite involved since types would need to be specified - I think graphql-tools `delegateToSchema` adds args by adding them as variables to the sub operation, perhaps we need to do that to get around needing explicit type specifications for arguments

If you call `delegateToComponent` from a resolver that has arguments, they will be propagated down to the delegated operation, however we currently dont have a way to pass args like we would in this example where you want to delegate from the non-root resolver such as Property.reviews passing the property id :

```graphql
# reviews component
type Review {
  id: ID
  content: String
}

type Query {
  reviewsByPropertyId(id: ID): [Review]
}

#### property component 
type Property {
  id: ID
  reviews: [Review]
}

type Query {
  propertyById(id: ID): Property
}
```

