### PR TITLE
1.x bug fixes and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To intercept resolvers with mocks execute this app with `GRAPHQL_MOCK=1` enabled
   - `context` - an optional object { namespace, factory } for contributing to context.
   - `directives` - an optional object containing custom schema directives.
   - `useMocks` - enable mocks.
-  - `preserveResolvers` - when mocks are enabled, preserve resolvers who are not overriden by a mock implementation
+  - `preserveResolvers` - when mocks are enabled, preserve resolvers which are not overridden by a mock implementation
   - `mocks` - an optional object containing mock types.
   - `dataSources` - an array of data sources instances to make available on `context.dataSources` .
   - `dataSourceOverrides` - overrides for data sources in the component tree.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To intercept resolvers with mocks execute this app with `GRAPHQL_MOCK=1` enabled
   - `context` - an optional object { namespace, factory } for contributing to context.
   - `directives` - an optional object containing custom schema directives.
   - `useMocks` - enable mocks.
-  - `preserveMockResolvers` - preserve type resolvers in mock mode.
+  - `preserveResolvers` - when mocks are enabled, preserve resolvers who are not overriden by a mock implementation
   - `mocks` - an optional object containing mock types.
   - `dataSources` - an array of data sources instances to make available on `context.dataSources` .
   - `dataSourceOverrides` - overrides for data sources in the component tree.

--- a/lib/delegate.js
+++ b/lib/delegate.js
@@ -1,0 +1,154 @@
+const { Kind, execute, isAbstractType, getNamedType, print } = require('graphql');
+const deepSet = require('lodash.set');
+const debug = require('debug')('graphql-component:delegate');
+
+/**
+ * extracts the Array<SelectionNode> at the given path
+ * @param {String} path - dot seperated string defining the path to the sub 
+ * selection
+ * @param {Array<SelectionNode>} selections - an array of SelectionNode objects
+ * @returns {Array<SelectionNode>} - an array of SelectionNode objects
+ * representing the sub selection set at the given sub path
+ */
+const getSelectionsForSubPath = function(path, selections) {
+  if (!path) {
+    return selections;
+  }
+  const parsedPath = path.split('.');
+  const getSelections = function (name, selections) {
+    for (const selection of selections) {
+      if ((selection.name && selection.name.value === name) || (selection.alias && selection.alias.value === name)) {
+        return selection.selectionSet && selection.selectionSet.selections;
+      }
+    }
+  };
+
+  let pathSegment = parsedPath.shift();
+  let subSelections = getSelections(pathSegment, selections);
+  while (parsedPath.length > 0 && !subSelections) {
+    pathSegment = parsedPath.shift();
+    subSelections = getSelections(pathSegment, subSelections);
+  }
+
+  if (subSelections) {
+    return subSelections;
+  }
+  return selections;
+}
+
+const createSubOperationDocument = function (targetRootField, subPath, info) {
+  
+  // default the selection set we delegate to the complete selection
+  // set starting at the calling resolver
+  let selections = info.fieldNodes.reduce((acc, fieldNode) => {
+    if (fieldNode.selectionSet && fieldNode.selectionSet.selections) {
+      return acc.concat(fieldNode.selectionSet.selections)
+    }
+  }, []);
+
+  // extract the selection set at the specified subPath
+  selections = getSelectionsForSubPath(subPath, selections);
+
+  // add in a top level __typename selection if the calling resolver's return type is Abstract
+  if (isAbstractType(getNamedType(info.returnType))) {
+    selections.push({
+      kind: Kind.FIELD,
+      name: { kind: Kind.NAME, value: '__typename' }
+    });
+  }
+
+  // extract the arguments from the calling resolver
+  let newArgs = info.fieldNodes.reduce((acc, fieldNode) => {
+    if (fieldNode.arguments) {
+      return acc.concat(fieldNode.arguments);
+    }
+  }, []);
+
+  const targetRootFieldNode = {
+    kind: Kind.FIELD,
+    arguments: newArgs,
+    name: { kind: Kind.NAME, value: targetRootField },
+    selectionSet: { kind: Kind.SELECTION_SET, selections }
+  };
+
+  const operationDefinition = {
+    kind: Kind.OPERATION_DEFINITION,
+    operation: info.operation.operation,
+    selectionSet: { kind: Kind.SELECTION_SET, selections: [targetRootFieldNode]},
+    variableDefinitions: info.operation.variableDefinitions
+  };
+
+  const definitions = [operationDefinition]
+  for (const [, fragmentDefinition] of Object.entries(info.fragments)) {
+    definitions.push(fragmentDefinition);
+  }
+  return {
+    kind: Kind.DOCUMENT,
+    definitions
+  };
+}
+
+/**
+ * executes (delegates) a graphql operation on the input component's schema
+ * @param {GraphQLComponent} component - the component to delegate execution to
+ * @param {object} options - an options object to customize the delegated 
+ * operation
+ * @param {GraphQLResolveInfo} options.info - the info object from the calling resolver
+ * @param {object} options.contextValue - the context object from the calling 
+ * resolver
+ * @param {string} [options.targetRootField] - the name of the root type field 
+ * the delegated operation will execute. Defaults to the field name of the 
+ * calling resolver
+ * @param {string} [options.subPath] - a dot separated string to limit the 
+ * delegated selection set to a given path in the calling resolver's return type
+ * @returns the result of the delegated operation to the targetRootField with
+ * any errors merged into the result at their given path
+ */
+const delegateToComponent = async function (component, options) { 
+  let {
+    subPath,
+    contextValue,
+    info,
+    targetRootField
+  } = options;
+
+  if (!contextValue) {
+    throw new Error('delegateToComponent requires the contextValue from the calling resolver');
+  }
+
+  if (!info) {
+    throw new Error('delegateToComponent requires the info object from the calling resolver');
+  }
+
+  // default the target root field to be the name of the calling resolver
+  if (!targetRootField) {
+    targetRootField = info.fieldName;
+  }
+
+  const document = createSubOperationDocument(targetRootField, subPath, info);
+
+  debug(`delegating ${print(document)} to ${component.name}`);
+
+  let { data, errors = [] } = await execute({
+    document, 
+    schema: component.schema, 
+    rootValue: info.rootValue, 
+    contextValue, 
+    variableValues: info.variableValues
+  });
+
+  // data can be completely null and destructuring defaults only apply to undefined
+  if (!data) {
+    data = {};
+  }
+  
+  if (errors.length > 0) {
+    for (const error of errors) {
+      deepSet(data, error.path, error);
+    }
+  }
+
+  return data[targetRootField];
+};
+
+module.exports = { delegateToComponent };

--- a/lib/index.js
+++ b/lib/index.js
@@ -104,6 +104,9 @@ class GraphQLComponent {
     let { data = {}, errors = [] } = await graphql.execute({ document, schema: this.schema, rootValue: root, contextValue: context, variableValues: variables });
 
     if (mergeErrors === true) {
+      if (!data) {
+        data = {};
+      }
       //Maps errors on to the result object
       if (errors.length > 0) {
         for (const error of errors) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@ const gql = require('graphql-tag');
 const { buildFederatedSchema } = require('@apollo/federation');
 const { makeExecutableSchema, addMockFunctionsToSchema, SchemaDirectiveVisitor } = require('graphql-tools');
 const { mergeResolvers, mergeTypeDefs } = require('graphql-toolkit');
-const { getImportedResolvers, transformResolvers, wrapResolvers } = require('./resolvers');
+const { getImportedResolvers, wrapResolvers } = require('./resolvers');
 const { wrapContext, createContext } = require('./context');
 const { getImportedTypes } = require('./types');
 const { buildFragments } = require('./fragments');
@@ -58,24 +58,22 @@ class GraphQLComponent {
     const importedDirectives = [];
 
     for (const imp of imports) {
+      let component;
+      let exclude;
+      let proxyImportedResolvers = true;
       if (GraphQLComponent.isComponent(imp)) {
-        const component = imp;
-        importedDirectives.push(getImportedDirectives(this, component));
-        importedTypes.push(...getImportedTypes(this, component));
-        importedResolvers.push(getImportedResolvers(component, true));
-        this._imports.push(component);
-        continue;
+        component = imp;
+      }
+      else {
+        // if it's not a component - assume it is a component config object
+        component = imp.component;
+        exclude = imp.exclude === undefined ? [] : imp.exclude;
+        proxyImportedResolvers = imp.proxyImportedResolvers === undefined ? true : imp.proxyImportedResolvers;
       }
 
-      const { component, exclude, proxyImportedResolvers = true } = imp;
-
-      const excludes = !exclude || !exclude.length ? [] : exclude.map((filter) => {
-        return filter.split('.');
-      });
-
       importedDirectives.push(getImportedDirectives(this, component));
-      importedTypes.push(...getImportedTypes(this, component, excludes));
-      importedResolvers.push(transformResolvers(getImportedResolvers(component, proxyImportedResolvers), excludes));
+      importedTypes.push(...getImportedTypes(this, component, exclude));
+      importedResolvers.push(getImportedResolvers(component, exclude, proxyImportedResolvers));
 
       this._imports.push(component);
     }
@@ -103,7 +101,7 @@ class GraphQLComponent {
   async execute(input, { mergeErrors = false, root = undefined, context = {}, variables = {} } = {}) {
     const document = typeof input === 'string' ? gql`${this._fragments.join('\n')}\n${input}` : input;
 
-    const { data = {}, errors = [] } = await graphql.execute({ document, schema: this.schema, rootValue: root, contextValue: context, variableValues: variables });
+    let { data = {}, errors = [] } = await graphql.execute({ document, schema: this.schema, rootValue: root, contextValue: context, variableValues: variables });
 
     if (mergeErrors === true) {
       //Maps errors on to the result object

--- a/lib/resolvers.js
+++ b/lib/resolvers.js
@@ -1,9 +1,9 @@
 'use strict';
 
 const debug = require('debug')('graphql-component:resolver');
-const { GraphQLScalarType, Kind, execute } = require('graphql');
+const { GraphQLScalarType } = require('graphql');
 const { mergeResolvers } = require('graphql-toolkit');
-const deepSet = require('lodash.set');
+const { delegateToComponent } = require('./delegate');
 
 /**
  * memoizes resolver functions such that calls of an identical resolver (args/context/path) within the same request context are avoided
@@ -50,42 +50,6 @@ const memoize = function (parentType, fieldName, resolve) {
 };
 
 /**
- * excludes types and/or fields on types from an input resolver map
- * @param {Object} resolvers - the resolver map to be transformed
- * @param {Array<string>} excludes - an array of exclusions in the general form 
- * of "type.field". This format supports excluding all types ('*'), an entire 
- * type and the fields it encloses ('type', 'type.', 'type.*'), and individual 
- * fields on a type ('type.somefield').
- * @returns {Object} - a new resolver map with the applied exclusions
- */
-const transformResolvers = function (resolvers, excludes) {
-  if (!excludes || excludes.length < 1) {
-    return resolvers;
-  }
-
-  let filteredResolvers = Object.assign({}, resolvers);
-
-  for (const [type, field] of excludes) {
-    if (type === '*') {
-      filteredResolvers = {};
-      break;
-    }
-    if (!field || field === '' || field === '*') {
-      delete filteredResolvers[type];
-      continue;
-    }
-    delete filteredResolvers[type][field];
-    // covers the case where all fields of a type were specified 1 by 1, which
-    // should result in the entire type being removed
-    if (Object.keys(filteredResolvers[type]).length === 0) {
-      delete filteredResolvers[type];
-    }
-  }
-
-  return filteredResolvers;
-};
-
-/**
  * binds an object context to resolver functions in the input resolver map
  * @param {Object} bind - the object context to bind to resolver functions
  * @param {Object} resolvers - the resolver map containing the resolver 
@@ -128,106 +92,6 @@ const wrapResolvers = function (bind, resolvers = {}) {
 };
 
 /**
- * helper function to extract the so-far traversed path from an info object 
- * passed to resolvers
- * @param {Object} info - the info object passed to resolvers
- * @returns {Array<String>} - the derived path from the input info object
- */
-const buildPathFromInfo = function (info) {
-  const path = [];
-  let current = info.path;
-
-  do {
-    path.unshift(current.key);
-    current = current.prev;
-  }
-  while (current !== undefined);
-
-  return path;
-};
-
-const getSelectionSetForPath = function (fieldPath, selectionSet) {
-  const getSelection = function (name, selections) {
-    for (const selection of selections) {
-      if (selection.name.value === name || selection.alias.value === name) {
-        return selection;
-      }
-    }
-  };
-
-  let path = fieldPath.shift();
-  let current = getSelection(path, selectionSet.selections);
-
-  while (fieldPath.length > 0) {
-    path = fieldPath.shift();
-    current = current && getSelection(path, current.selectionSet.selections);
-  }
-
-  return current;
-};
-
-const createSubOperationForField = function (component, fieldPath, info) {
-  const operation = info.operation;
-  const fragments = info.fragments;
-
-  const definitions = [];
-
-  if (fragments) {
-    for (const [, fragmentDefinition] of Object.entries(fragments)) {
-      definitions.push(fragmentDefinition);
-    }
-  }
-
-  const selections = getSelectionSetForPath([...fieldPath], operation.selectionSet);
-
-  definitions.push({
-    kind: Kind.OPERATION_DEFINITION,
-    operation: operation.operation,
-    variableDefinitions: operation.variableDefinitions,
-    selectionSet: {
-      kind: Kind.SELECTION_SET,
-      selections: [
-        selections
-      ]
-    }
-  });
-
-  return {
-    kind: Kind.DOCUMENT,
-    definitions
-  };
-};
-
-const delegateToComponent = async function (component, { subPath, contextValue, info }) {
-  const rootPath = buildPathFromInfo(info);
-  const fieldPath = subPath !== undefined ? [...rootPath, ...subPath.split('.')] : rootPath;
-
-  const { rootValue, variableValues } = info;
-  
-  const document = createSubOperationForField(component, fieldPath, info);
-  
-  const { data = {}, errors = [] } = await execute({ document, schema: component.schema, rootValue, contextValue, variableValues });
-  
-  if (errors.length > 0) {
-    for (const error of errors) {
-      deepSet(data, error.path, error);
-    }
-  }
-
-  let result = {};
-
-  //do not count current field resolver in path since that will exist in data result
-  deepSet(result, rootPath.length > 1 ? rootPath.slice(0, rootPath.length - 1) : rootPath, data);
-  
-  while (fieldPath.length > 0) {
-    let path = fieldPath.shift();
-    result = result[path];
-  }
-  
-  return result;
-};
-
-/**
  * returns a function that delegates execution to a resolver implementation's 
  * owning component
  * @param {Object} component - the component to delegate execution to
@@ -241,10 +105,7 @@ const delegateToComponent = async function (component, { subPath, contextValue, 
 const createProxyResolver = function (component, rootType, fieldName) {
   const proxyResolver = async function (_parent, args, contextValue, info) {
     debug(`delegating ${rootType}.${fieldName} to ${component.constructor.name}`);
-    
-    const result = await delegateToComponent(component, { contextValue, info });
-    
-    return result[info.path.key];
+    return delegateToComponent(component, { info, contextValue });
   };
 
   proxyResolver.__isProxy = true;
@@ -288,17 +149,19 @@ const createProxyResolvers = function (component, resolvers) {
 };
 
 /**
- * combine a component's own resolvers with its imported resolvers
- * @param {Object} component - the component whose own resolvers and imported r
- * esolvers will be combined into 1 resolver map
+ * import resolvers from an input component
+ * @param {Object} component - the component whose resolvers will be imported
+ * @param {Array<string>} - An array of dot separated strings specifying Type.
+ * field exclusions
  * @param {Boolean} proxyImportedResolvers - whether or not to replace the 
  * input component's root type field resolvers with a proxy
  * @returns {Object} - the combined resolver map
  */
-const getImportedResolvers = function (component, proxyImportedResolvers) {
-  const mergedResolvers = Object.assign({}, mergeResolvers([component._resolvers, component._importedResolvers]));
+const getImportedResolvers = function (component, exclude, proxyImportedResolvers) {
+  // merge the component's own resolvers with its imported resolvers (with exclusions, if any) into one resolver map
+  let mergedResolvers = Object.assign({}, mergeResolvers([component._resolvers, component._importedResolvers], { exclusions: exclude }));
 
   return proxyImportedResolvers === true ? createProxyResolvers(component, mergedResolvers) : mergedResolvers;
 };
 
-module.exports = { memoize, transformResolvers, wrapResolvers, getImportedResolvers, createProxyResolvers, createProxyResolver, delegateToComponent };
+module.exports = { memoize, wrapResolvers, getImportedResolvers, createProxyResolver, delegateToComponent };

--- a/lib/types.js
+++ b/lib/types.js
@@ -12,7 +12,7 @@ const check = function (operation, fieldName, excludes) {
   }).some(check => check);
 };
 
-const exclude = function (types, excludes) {
+const excludeTypes = function (types, excludes) {
   if (!excludes || excludes.length < 1) {
     return types;
   }
@@ -70,10 +70,13 @@ const namespaceDirectives = function (directives, id, document) {
   return document;
 };
 
-const getImportedTypes = function (parent, component, excludes) {
+const getImportedTypes = function (parent, component, exclude) {
+  const excludes = !exclude || !exclude.length ? [] : exclude.map((filter) => {
+    return filter.split('.');
+  }); 
   const types = component._types.map((type) => namespaceDirectives(parent._directives || {}, component._id, parse(type)));
   const importedTypes = component._importedTypes;
-  return exclude([...types, ...importedTypes], excludes);
+  return excludeTypes([...types, ...importedTypes], excludes);
 };
 
-module.exports = { exclude, check, getImportedTypes };
+module.exports = { excludeTypes, check, getImportedTypes };

--- a/test/test-delegate.js
+++ b/test/test-delegate.js
@@ -2,10 +2,12 @@
 
 const Test = require('tape');
 const GraphQLComponent = require('../lib');
+const graphql = require('graphql');
+const gql = require('graphql-tag');
 
-Test('component resolver delegate', async (t) => {
+Test('automatic imported root resolver delegation', async (t) => {
 
-  t.plan(1);
+  t.plan(2);
 
   const component = new GraphQLComponent({
     imports: [
@@ -31,14 +33,26 @@ Test('component resolver delegate', async (t) => {
     ]
   });
 
-  const { test } = await component.execute(`query { test { ...AllTest } }`, { mergeErrors: true });
+  const document = gql`
+    query {
+      test { value }
+    }
+  `;
+
+  const { data, errors } = await graphql.execute({
+    document,
+    schema: component.schema,
+    rootValue: undefined,
+    contextValue: {}
+  });
   
-  t.equal(test.value, true, 'resolved');
+  t.equal(data.test.value, true, 'resolved');
+  t.notOk(errors, 'no errors');
 });
 
-Test('component resolver delegate errors', async (t) => {
+Test('automatic imported root resolver delegation with errors', async (t) => {
 
-  t.plan(2);
+  t.plan(4);
 
   const component = new GraphQLComponent({
     imports: [
@@ -73,8 +87,142 @@ Test('component resolver delegate errors', async (t) => {
     ]
   });
 
-  const { test } = await component.execute(`query { test { ...AllTest } }`, { mergeErrors: true });
+  const successDocument = gql`
+    query {
+      test { value }
+    }
+  `;
+
+  const errorDocument = gql`
+    query {
+      test {
+        value
+        err
+      }
+    }
+  `;
+
+  const successResult = await graphql.execute({
+    document: successDocument,
+    schema: component.schema,
+    rootValue: undefined,
+    contextValue: {}
+  });
   
-  t.equal(test.value, true, 'resolved');
-  t.ok(test.err instanceof Error, 'got error');
+  t.equal(successResult.data.test.value, true, 'resolved');
+  t.notOk(successResult.errors, 'no errors');
+
+  const errorResult = await graphql.execute({
+    document: errorDocument,
+    schema: component.schema,
+    rootValue: undefined,
+    contextValue: {}
+  });
+  
+  t.equal(errorResult.data.test.value, true, 'resolved');
+  t.equal(errorResult.errors[0].message, 'error', 'error propagated properly');
+});
+
+Test('automatic imported root resolver delegation with errors (return type not nullable)', async (t) => {
+
+  t.plan(2);
+
+  const component = new GraphQLComponent({
+    imports: [
+      new GraphQLComponent({
+        types: `
+          type Test {
+            value: Boolean
+          }
+          type Query {
+            test: Test!
+          }
+        `,
+        resolvers: {
+          Query: {
+            test() {
+              throw new Error('error in proxied root resolver');
+            }
+          }
+        }
+      })
+    ]
+  });
+
+  const document = gql`
+    query {
+      test {
+        value
+      }
+    }
+  `;
+
+  const {data, errors} = await graphql.execute({
+    document,
+    schema: component.schema,
+    rootValue: undefined,
+    contextValue: {}
+  });
+  
+  t.notOk(data, 'data is null');
+  t.equal(errors[0].message, 'error in proxied root resolver', 'error propagated properly');
+});
+
+Test('automatic root resolver delegation with abstract return type', async (t) => {
+  t.plan(3);
+
+  let resolveTypeCallCount = 0;
+  const component = new GraphQLComponent({
+    imports: [
+      new GraphQLComponent({
+        types: `
+          interface ITest {
+            id: ID
+          }
+          type Test implements ITest {
+            id: ID
+            value: Boolean
+          }
+          type Query {
+            test: ITest
+          }
+        `,
+        resolvers: {
+          Query: {
+            test() {
+              return { id: 1, value: true };
+            }
+          },
+          ITest: {
+            __resolveType(i) {
+              resolveTypeCallCount = resolveTypeCallCount + 1;
+              if (i.value) {
+                return 'Test'
+              }
+            }
+          }
+        }
+      })
+    ]
+  });
+
+  const document = gql`
+    query {
+      test {
+        id
+        value
+      }
+    }
+  `;
+
+  const {data, errors} = await graphql.execute({
+    document,
+    schema: component.schema,
+    rootValue: undefined,
+    contextValue: {}
+  });
+  
+  t.deepEqual(data.test, { id: '1', value: true});
+  t.equals(resolveTypeCallCount, 1, '__resolveType in import only called 1 time');
+  t.notOk(errors, 'no errors');
 });

--- a/test/test-execute.js
+++ b/test/test-execute.js
@@ -13,6 +13,7 @@ Test('test component execute', (t) => {
     }
     type Query {
       book(id: ID!) : Book
+      bookNonNullable(id: ID!): Book!
     }
   `];
 
@@ -23,6 +24,9 @@ Test('test component execute', (t) => {
           id,
           title: 'Some Title'
         };
+      },
+      bookNonNullable() {
+        throw new Error('error from resolver with non-nullable return');
       }
     }
   };
@@ -116,6 +120,20 @@ Test('test component execute', (t) => {
     const result = await component.execute(query, { mergeErrors: true });
 
     t.deepEqual(result, { one: { title: 'Some Title' }, two: { id: '2', title: 'Some Title' } }, 'data returned');
+  });
+
+  t.test('execute error merged (non nullable return type)', async (t) => {
+    t.plan(1);
+    const query = `
+      query {
+        bookNonNullable(id: "1") {
+          title
+        }
+      }
+    `;
+    
+    const result = await component.execute(query, { mergeErrors: true });
+    t.ok(result.bookNonNullable instanceof Error, 'error set at path when graphql.execute returns completely null response');
   });
 
 });

--- a/test/test-types.js
+++ b/test/test-types.js
@@ -87,7 +87,7 @@ Test('type utilities', (t) => {
       `]
     };
 
-    const types = Types.getImportedTypes({}, component, [['Query', 'b']]);
+    const types = Types.getImportedTypes({}, component, ['Query.b']);
     const schemaA = buildASTSchema(types[0]);
     t.ok(schemaA.getType('A').getFields().value, `the "A" type exists in component's schema`);
     t.ok(schemaA.getQueryType().getFields().a, `the "a" query exists in component's schema`);
@@ -114,7 +114,7 @@ Test('type utilities', (t) => {
       `]
     };
 
-    let types = Types.getImportedTypes({}, component, [['Query', 'a']]);
+    let types = Types.getImportedTypes({}, component, ['Query.a']);
     let schema = buildASTSchema(types[0]);
     t.ok(schema.getType('A').getFields().value, `the "A" type exists in component's schema`);
     t.notOk(schema.getQueryType().getFields().a, `the "a" query does not exist in component's schema`);
@@ -144,7 +144,7 @@ Test('type utilities', (t) => {
       `]
     };
 
-    const types = Types.getImportedTypes({}, component, [['*']]);
+    const types = Types.getImportedTypes({}, component, ['*']);
     const schema = buildASTSchema(types[0]);
     t.notOk(schema.getQueryType(), `the "Query" type does not exist in component's schema because all of it's fields were removed`);
     t.notOk(schema.getMutationType(), `the "Mutation" type does not exist in component's schema because all of its fields were removed`);
@@ -177,7 +177,7 @@ Test('type utilities', (t) => {
       `]
     };
 
-    const types = Types.getImportedTypes({}, component, [['Mutation', 'b1'], ['Query', 'b']]);
+    const types = Types.getImportedTypes({}, component, ['Mutation.b1', 'Query.b']);
     const schemaA = buildASTSchema(types[0]);
     t.ok(schemaA.getType('A').getFields().value, `the "A" type exists in component's schema`);
     t.ok(schemaA.getQueryType().getFields().a, `the "a" query exists in component's schema`);


### PR DESCRIPTION
* pulls in new delegateToComponent implementation which resolves abstract type bug in some cases and prohibits need to pull up abstrat type resolvers
* clean up import loop in constructor
* remove transformResolvers in lieu of exclusion functionality found in `mergeResolvers`
* minor tweaks to type exclusion to support simpler import loop
* fixes execute when graphql.execute() returns { data: null }