### PR TITLE
update CHANGELOG and version for 1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### UNRELEASED
 
+### v1.3.2
+- Fixed index.d.ts to support ES6 syntax
+- Cleaned up import loop
+- Fixed `execute()` merge errors functionality when `graphql.execute()` returns a completely null value
+- Fixed proxying an imported root type resolver when the return type is abstract
+
 ### v1.3.1
 
 - Fixed exclude mapping in GraphQLComponent constructor - Array.map was erroniously changed to Array.filter

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-component",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Build graphql schema with components",
   "keywords": [
     "graphql",


### PR DESCRIPTION
can't push directly to v1.x - so a PR will do - then we can cut a release from the v1.x branch