### PR TITLE
add arg passing functionality to delegateToComponent

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,14 @@ To intercept resolvers with mocks execute this app with `GRAPHQL_MOCK=1` enabled
   - `dataSources` - an array of data sources instances to make available on `context.dataSources` .
   - `dataSourceOverrides` - overrides for data sources in the component tree.
   - `federation` - enable building a federated schema (default: `false`).
-- `GraphQLComponent.delegateToComponent(component, options)` - helper for delegating a sub-query to another component
-  - `component` - the component to delegate to.
-  - `options` - additional options:
-    - `subPath` - optional subPath to extract sub-query from
-    - `contextValue` - the context (required).
-    - `info` - the info object from the calling resolver (required).
+- `GraphQLComponent.delegateToComponent(component, options)` - helper for delegating an operation to another component's schema and returning the GraphQL result. When called from a resolver, this function will examine the passed `info` object and will automatically forward the remaining operation selection set (or a limited subset of the selection set) to a root type field in the input component's schema.
+  - `component` (instance of `GraphQLComponent`) - the component's whose schema will be the target of the delegated operation
+  - `options` (`Object`)
+    - `contextValue` (required) - the `context` object from resolver that calls `delegateToComponent`
+    - `info` (required) - the `info` object from the resolver that calls `delegateToComponent`
+    - `targetRootField` (`string`, optional) - if the calling resolver's field name is different from the root field name on the delegatee, you can specify the desired root field on the delegatee that you want to execute
+    - `subPath` (`string`, optional)- a dot separated path into the incoming selection set (from the calling resolver) that represents the root of the delegated selection set (limits delegated selection set)
+    - `args` (`object`, optional) -  an object literal whose keys/values are passed as args to the delegatee's target field resolver. By default, the resolver's args from which `delegateToComponent` is called will be passed if the target field has an argument of the same name. Otherwise, arguments passed via the `args` object will override the calling resolver's args of the same name.
 
 A new GraphQLComponent instance has the following API:
 
@@ -233,17 +235,3 @@ context.use('transformRawRequest', ({ request }) => {
 ```
 
 Using `context` now in `apollo-server-hapi` for example, will transform the context to one similar to default `apollo-server`.
-
-### Delegating root-type operations to a component
-GraphQLComponent exposes a static function called `delegateToComponent` that provides functionality for delegating execution of a operation (ie. `query`, `mutation`) to a given component. In general, delegateToComponent is meant to be somewhat opinionated/restrictive in order to encourage more formal links or connections between types defined in seperate components. `delegateToComponent` can be called from a component's root or non-root type field resolvers.
-
-#### static delegateToComponent(component, options) => delegated graphql execution result
-* component: the component to delegate execution to
-* options: an object whose properties facilitate delegation of a graphql operation to the input component
-  * `contextValue` (required): the `context` object from resolver that calls `delegateToComponent`
-  * `info` (required): the `info` object from the resolver that calls `delegateToComponent`
-  * `targetRootField` (`string`, optional): if the calling resolver's field name is different from the root field name on the delegatee, you can specify the desired root field on the delegatee that you want to execute
-  * `subPath` (`string`, optional): dot separated string designating a path into the incoming selection set that will limit the selection set in delegated operation
-
-
-

--- a/lib/delegate/__tests__.js
+++ b/lib/delegate/__tests__.js
@@ -112,6 +112,148 @@ Test('integration - composite automatically delegates subscription', async (t) =
   t.end();
 });
 
+Test('contextValue not passed to delegateToComponent', async (t) => {
+  const primitive = new GraphQLComponent({
+    types: `
+      type A {
+        aField: String
+        anotherAField: String
+      }
+      type Query {
+        a: A
+      }
+    `,
+    resolvers: {
+      Query: {
+        a() {
+          return {
+            aField: 'a field',
+            anotherAField: 'another a field'
+          }
+        }
+      }
+    }
+  });
+
+  const composite = new GraphQLComponent({
+    types: `
+      type A {
+        addedField: String
+      }
+      type Query {
+        a: A
+      }
+    `,
+    resolvers: {
+      Query: {
+        a: async function (_, _args, context, info) {
+          return GraphQLComponent.delegateToComponent(primitive, {
+            info
+          });
+        }
+      },
+      A: {
+        addedField() {
+          return 'added field'
+        }
+      }
+    },
+    imports: [
+      primitive
+    ]
+  });
+
+  const document = gql`
+    query { 
+      a {
+        aField
+        addedField
+      }
+    }
+  `;
+
+  const result = await graphql.execute({
+    document,
+    schema: composite.schema,
+    rootValue: undefined,
+    contextValue: {}
+  });
+  t.equals(result.data.a, null, 'expected null response');
+  t.equals(result.errors[0].message, 'delegateToComponent requires the contextValue from the calling resolver', 'meaningful error message regarding required contextValue is propagated');
+  t.end();
+});
+
+Test('info not passed to delegateToComponent', async (t) => {
+  const primitive = new GraphQLComponent({
+    types: `
+      type A {
+        aField: String
+        anotherAField: String
+      }
+      type Query {
+        a: A
+      }
+    `,
+    resolvers: {
+      Query: {
+        a() {
+          return {
+            aField: 'a field',
+            anotherAField: 'another a field'
+          }
+        }
+      }
+    }
+  });
+
+  const composite = new GraphQLComponent({
+    types: `
+      type A {
+        addedField: String
+      }
+      type Query {
+        a: A
+      }
+    `,
+    resolvers: {
+      Query: {
+        a: async function (_, _args, context) {
+          return GraphQLComponent.delegateToComponent(primitive, {
+            contextValue: context
+          });
+        }
+      },
+      A: {
+        addedField() {
+          return 'added field'
+        }
+      }
+    },
+    imports: [
+      primitive
+    ]
+  });
+
+  const document = gql`
+    query { 
+      a {
+        aField
+        addedField
+      }
+    }
+  `;
+  
+  const result = await graphql.execute({
+    document,
+    schema: composite.schema,
+    rootValue: undefined,
+    contextValue: {}
+  });
+  t.equals(result.data.a, null, 'expected null response');
+  t.equals(result.errors[0].message, 'delegateToComponent requires the info object from the calling resolver', 'meaningful error message regarding required info object is propagated');
+  t.end();
+});
+
 Test('composite component delegates from root type resolver to primitive component field with same name, no sub path', async (t) => {
   const primitive = new GraphQLComponent({
     types: `
@@ -894,7 +1036,7 @@ Test('delegateToComponent - return type is abstract (__typename requested)', asy
   t.end();
 });
 
-Test('delegateToComponent - calling resolver args are passed to primitive component (reviews) field', async (t) => {
+Test('delegateToComponent - calling resolver arg is not passed when target root field does not have matching arg', async (t) => {
   const reviews = new GraphQLComponent({
     types: `
       type Review {
@@ -903,13 +1045,13 @@ Test('delegateToComponent - calling resolver args are passed to primitive compon
       }
 
       type Query {
-        reviewsByPropertyId(id: ID): [Review]
+        reviewsByPropertyId: [Review]
       }
     `,
     resolvers: {
       Query: {
         reviewsByPropertyId(_root, args) {
-          t.equals(args.id, '1', 'property id from parent resolver passed to child');
+          t.equals(Object.keys(args).length, 0, 'property id arg is not passed');
           return [{ id: 'revid', content: 'some review content'}];
         }
       }
@@ -961,3 +1103,468 @@ Test('delegateToComponent - calling resolver args are passed to primitive compon
   t.deepEqual(result.data, { propertyById: { id: '1', reviews: [{ id: 'revid', content: 'some review content'}]}}, 'propery reviews successfully resolved');
   t.end();
 });
+
+Test('delegateToComponent - calling resolver arg is passed if target root field has matching arg', async (t) => {
+  const reviews = new GraphQLComponent({
+    types: `
+      type Review {
+        id: ID
+        content: String
+      }
+
+      type Query {
+        reviewsByPropertyId(id: ID): [Review]
+      }
+    `,
+    resolvers: {
+      Query: {
+        reviewsByPropertyId(_root, args) {
+          t.equals(args.id, '1', 'property id from calling resolver is passed');
+          return [{ id: 'revid', content: 'some review content'}];
+        }
+      }
+    }
+  });
+
+  const property = new GraphQLComponent({
+    types: `
+      type Property {
+        id: ID
+        reviews: [Review]
+      }
+
+      type Query {
+        propertyById(id: ID): Property
+      }
+    `,
+    resolvers: {
+      Query: {
+        async propertyById(root, args, context, info) {
+          const revs = await GraphQLComponent.delegateToComponent(reviews, {
+            targetRootField: 'reviewsByPropertyId',
+            subPath: 'reviews',
+            info,
+            contextValue: context
+          })
+          return { id: args.id, reviews: revs }
+        }
+      }
+    },
+    imports: [reviews]
+  });
+
+  const result = await graphql.execute({
+    document: gql`
+      query {
+        propertyById(id: 1) {
+          id
+          reviews {
+            id
+            content
+          }
+        }
+      }
+    `,
+    schema: property.schema,
+    contextValue: {}
+  });
+  t.deepEqual(result.data, { propertyById: { id: '1', reviews: [{ id: 'revid', content: 'some review content'}]}}, 'propery reviews successfully resolved');
+  t.end();
+});
+
+Test('delegateToComponent - user arg is passed and overrides calling resolver arg', async (t) => {
+  const reviews = new GraphQLComponent({
+    types: `
+      type Review {
+        id: ID
+        content: String
+      }
+
+      type Query {
+        reviewsByPropertyId(id: ID): [Review]
+      }
+    `,
+    resolvers: {
+      Query: {
+        reviewsByPropertyId(_root, args) {
+          t.equals(Object.keys(args).length, 1, 'only 1 arg is passed');
+          t.equals(args.id, '2', 'id arg from delegateToComponent call is passed');
+          return [{ id: 'revid', content: 'some review content'}];
+        }
+      }
+    }
+  });
+
+  const property = new GraphQLComponent({
+    types: `
+      type Property {
+        id: ID
+        reviews: [Review]
+      }
+
+      type Query {
+        propertyById(id: ID): Property
+      }
+    `,
+    resolvers: {
+      Query: {
+        async propertyById(root, args, context, info) {
+          const revs = await GraphQLComponent.delegateToComponent(reviews, {
+            targetRootField: 'reviewsByPropertyId',
+            subPath: 'reviews',
+            info,
+            contextValue: context,
+            args: {id: 2}
+          })
+          return { id: args.id, reviews: revs };
+        }
+      }
+    },
+    imports: [reviews]
+  });
+
+  const result = await graphql.execute({
+    document: gql`
+      query {
+        propertyById(id: 1) {
+          id
+          reviews {
+            id
+            content
+          }
+        }
+      }
+    `,
+    schema: property.schema,
+    contextValue: {}
+  });
+  t.deepEqual(result.data, { propertyById: { id: '1', reviews: [{ id: 'revid', content: 'some review content'}]}}, 'propery reviews successfully resolved');
+  t.end();
+});
+
+Test('delegateToComponent - calling resolver and user provided arg are passed', async (t) => {
+  const reviews = new GraphQLComponent({
+    types: `
+      type Review {
+        id: ID
+        content: String
+      }
+
+      type Query {
+        reviewsByPropertyId(id: ID, limit: Int): [Review]
+      }
+    `,
+    resolvers: {
+      Query: {
+        reviewsByPropertyId(_root, args) {
+          t.equals(args.id, '1', 'property id from calling resolver is passed');
+          t.equals(args.limit, 10, 'limit arg from delegateToComponent is passed');
+          return [{ id: 'revid', content: 'some review content'}];
+        }
+      }
+    }
+  });
+
+  const property = new GraphQLComponent({
+    types: `
+      type Property {
+        id: ID
+        reviews: [Review]
+      }
+
+      type Query {
+        propertyById(id: ID): Property
+      }
+    `,
+    resolvers: {
+      Query: {
+        async propertyById(root, args, context, info) {
+          const revs = await GraphQLComponent.delegateToComponent(reviews, {
+            targetRootField: 'reviewsByPropertyId',
+            subPath: 'reviews',
+            info,
+            contextValue: context,
+            args: { limit: 10 }
+          })
+          return { id: args.id, reviews: revs };
+        }
+      }
+    },
+    imports: [reviews]
+  });
+
+  const result = await graphql.execute({
+    document: gql`
+      query {
+        propertyById(id: 1) {
+          id
+          reviews {
+            id
+            content
+          }
+        }
+      }
+    `,
+    schema: property.schema,
+    contextValue: {}
+  });
+  t.deepEqual(result.data, { propertyById: { id: '1', reviews: [{ id: 'revid', content: 'some review content'}]}}, 'propery reviews successfully resolved');
+  t.end();
+});
+
+Test('delegateToComponent - user provided args of various types: ID (as Int), ID (as string), String, Int, Float, Boolean, enum, input object are passed', async (t) => {
+  const reviewsComponent = new GraphQLComponent({
+    types: `
+      type Review {
+        id: ID
+        content: String
+      }
+
+      input Dates {
+        from: String
+        to: String
+      }
+
+      enum Status {
+        PENDING
+        COMPLETE
+      }
+
+      type Query {
+        reviewsByPropertyId(
+          id: ID!
+          anotherId: ID!
+          bool: Boolean!
+          int: Int!
+          float: Float!
+          string: String!
+          status: Status!
+          dates: Dates!): [Review]
+      }
+    `,
+    resolvers: {
+      Query: {
+        reviewsByPropertyId(_root, args) {
+          t.equals(Object.keys(args).length, 8, 'exactly 8 args passed');
+          t.equals(args.id, '2', 'id ID arg (passed as number) from delegateToComponent call passed');
+          t.equals(args.anotherId, '9', 'anotherId ID (passed as string) from delegateToComponent call passed');
+          t.equals(args.bool, true, 'bool Boolean arg from delegateToComponent call passed');
+          t.equals(args.int, 101, 'int Int arg from delegateToComponent call passed');
+          t.equals(args.float, 49.2, 'float Float arg from delegateToComponent passed');
+          t.equals(args.string, 'foobar', 'string String arg from delegateToComponent call passed');
+          t.equals(args.status, 'COMPLETE', 'status enum arg from delegateToComponent call passed');
+          t.deepEqual(args.dates, {from: 'from-date', to: 'to-date'}, 'dates input object arg from delegateToComponent call passed');
+          return [{ id: 'revid', content: 'some review content'}];
+        }
+      }
+    }
+  });
+
+  const property = new GraphQLComponent({
+    types: `
+      type Property {
+        id: ID
+        reviews: [Review]
+      }
+
+      type Query {
+        propertyById(id: ID): Property
+      }
+    `,
+    resolvers: {
+      Query: {
+        propertyById() {
+          return { id: 1 };
+        }
+      },
+      Property: {
+        async reviews(_root, _args, context, info) {
+          const reviews = await GraphQLComponent.delegateToComponent(reviewsComponent, {
+            info,
+            contextValue: context,
+            targetRootField: 'reviewsByPropertyId',
+            args: { 
+              id: 2,
+              anotherId: '9',
+              bool: true,
+              int: 101,
+              float: 49.2,
+              string: 'foobar',
+              status: 'COMPLETE',
+              dates: { from: 'from-date', to: 'to-date' }
+            }
+          });
+          return reviews;
+        }
+      }
+    },
+    imports: [reviewsComponent]
+  });
+
+  const result = await graphql.execute({
+    document: gql`
+      query {
+        propertyById(id: 1) {
+          id
+          reviews {
+            id
+            content
+          }
+        }
+      }
+    `,
+    schema: property.schema,
+    contextValue: {}
+  });
+  t.deepEqual(result.data, { propertyById: { id: '1', reviews: [{ id: 'revid', content: 'some review content'}]}}, 'propery reviews successfully resolved');
+  t.end();
+});
+
+Test('delegateToComponent - user passes wrong type for arg', async (t) => {
+  const reviewsComponent = new GraphQLComponent({
+    types: `
+      type Review {
+        id: ID
+        content: String
+      }
+
+      type Query {
+        reviewsByPropertyId(id: ID!): [Review]
+      }
+    `,
+    resolvers: {
+      Query: {
+        reviewsByPropertyId() {
+          return [{ id: 'revid', content: 'some review content'}];
+        }
+      }
+    }
+  });
+
+  const property = new GraphQLComponent({
+    types: `
+      type Property {
+        id: ID
+        reviews: [Review]
+      }
+
+      type Query {
+        propertyById(id: ID): Property
+      }
+    `,
+    resolvers: {
+      Query: {
+        propertyById() {
+          return { id: 1 };
+        }
+      },
+      Property: {
+        async reviews(_root, _args, context, info) {
+          const reviews = await GraphQLComponent.delegateToComponent(reviewsComponent, {
+            info,
+            contextValue: context,
+            targetRootField: 'reviewsByPropertyId',
+            args: {
+              id: true
+            }
+          });
+          return reviews;
+        }
+      }
+    },
+    imports: [reviewsComponent]
+  });
+
+  const result = await graphql.execute({
+    document: gql`
+      query {
+        propertyById(id: 1) {
+          id
+          reviews {
+            id
+            content
+          }
+        }
+      }
+    `,
+    schema: property.schema,
+    contextValue: {}
+  });
+  t.deepEqual(result.data, { propertyById: { id: '1', reviews: null } }, 'property partially resolves, reviews null');
+  t.equal(result.errors[0].message, 'Invalid value true: Expected type ID. ID cannot represent value: true', 'type mismatch error propagated');
+  t.end();
+});
+
+Test('delegateToComponent - target field non-nullable arg is not passed', async (t) => {
+  const reviewsComponent = new GraphQLComponent({
+    types: `
+      type Review {
+        id: ID
+        content: String
+      }
+
+      type Query {
+        reviewsByPropertyId(id: ID!): [Review]
+      }
+    `,
+    resolvers: {
+      Query: {
+        reviewsByPropertyId() {
+          return [{ id: 'revid', content: 'some review content'}];
+        }
+      }
+    }
+  });
+
+  const property = new GraphQLComponent({
+    types: `
+      type Property {
+        id: ID
+        reviews: [Review]
+      }
+
+      type Query {
+        propertyById(id: ID): Property
+      }
+    `,
+    resolvers: {
+      Query: {
+        propertyById() {
+          return { id: 1 };
+        }
+      },
+      Property: {
+        async reviews(_root, _args, context, info) {
+          const reviews = await GraphQLComponent.delegateToComponent(reviewsComponent, {
+            info,
+            contextValue: context,
+            targetRootField: 'reviewsByPropertyId'
+          });
+          return reviews;
+        }
+      }
+    },
+    imports: [reviewsComponent]
+  });
+
+  const result = await graphql.execute({
+    document: gql`
+      query {
+        propertyById(id: 1) {
+          id
+          reviews {
+            id
+            content
+          }
+        }
+      }
+    `,
+    schema: property.schema,
+    contextValue: {}
+  });
+  t.deepEqual(result.data, { propertyById: { id: '1', reviews: null } }, 'property partially resolves, reviews null');
+  t.equal(result.errors[0].message, `Argument "id" of required type "ID!" was not provided.`, 'required arg error message is propagated');
+  t.end();
+});
+
+

--- a/lib/delegate/index.js
+++ b/lib/delegate/index.js
@@ -1,4 +1,5 @@
-const { Kind, execute, subscribe, isAbstractType, getNamedType, print } = require('graphql');
+
+const { Kind, execute, subscribe, isAbstractType, getNamedType, print, astFromValue, coerceInputValue } = require('graphql');
 const deepSet = require('lodash.set');
 const debug = require('debug')('graphql-component:delegate');
 
@@ -36,17 +37,17 @@ const getSelectionsForSubPath = function(path, selections) {
   return selections;
 }
 
-const createSubOperationDocument = function (targetRootField, subPath, info) {
+const createSubOperationDocument = function (component, targetRootField, args, subPath, info) {
   
-  // default the selection set we delegate to the complete selection
-  // set starting at the calling resolver
-  let selections = info.fieldNodes.reduce((acc, fieldNode) => {
+  // grab the selections starting at the calling resolver forward
+  let selections = [];
+  for (const fieldNode of info.fieldNodes) {
     if (fieldNode.selectionSet && fieldNode.selectionSet.selections) {
-      return acc.concat(fieldNode.selectionSet.selections)
+      selections.push(...fieldNode.selectionSet.selections);
     }
-  }, []);
+  }
 
-  // extract the selection set at the specified subPath
+  // reduce the selection set to the specified sub path if provided
   selections = getSelectionsForSubPath(subPath, selections);
 
   // add in a top level __typename selection if the calling resolver's return type is Abstract
@@ -57,16 +58,80 @@ const createSubOperationDocument = function (targetRootField, subPath, info) {
     });
   }
 
-  // extract the arguments from the calling resolver
-  let newArgs = info.fieldNodes.reduce((acc, fieldNode) => {
-    if (fieldNode.arguments) {
-      return acc.concat(fieldNode.arguments);
+  let targetRootTypeFields;
+  if (info.operation.operation === 'query') {
+    targetRootTypeFields = component.schema.getQueryType().getFields();
+  } 
+  else if (info.operation.operation === 'mutation') {
+    targetRootTypeFields = component.schema.getMutationType().getFields();
+  } 
+  else if (info.operation.operation === 'subscription') {
+    targetRootTypeFields = component.schema.getSubscriptionType().getFields();
+  }
+
+  // get the arguments defined by the target root field
+  const definedRootFieldArgs = [];
+  for (const [fieldName, fieldValue] of Object.entries(targetRootTypeFields)) {
+    if (fieldName === targetRootField) {
+      definedRootFieldArgs.push(...fieldValue.args);
     }
-  }, []);
+  }
+
+  const targetRootFieldArguments = [];
+  // skip argument processing if the target root field doesn't have any arguments
+  if (definedRootFieldArgs.length > 0) {
+    // get the calling resolver's arguments
+    const callingResolverArgs = [];
+    for (const fieldNode of info.fieldNodes) {
+      if (fieldNode.arguments && fieldNode.arguments.length > 0) {
+        callingResolverArgs.push(...fieldNode.arguments);
+      }
+    }
+
+    // if the user didn't provide args, default to the calling resolver's args
+    if (Object.keys(args).length === 0) {
+      targetRootFieldArguments.push(...callingResolverArgs);
+    }
+    else {
+      // for each target root field defined argument, see if the user provided
+      // an argument of the same name, if so, construct the argument node
+      // and remove the calling resolver's matching argument if present
+      // so that the user provided arg overrides calling resolver args
+      for (const definedArg of definedRootFieldArgs) {
+        if (args[definedArg.name]) {
+          const definedArgNamedType = getNamedType(definedArg.type);
+          // this provides us some type safety by trying to coerce the user's
+          // argument value to the type defined by the target field's matching 
+          // argument - if they dont match, it will throw a meaningful error.
+          // without this astFromValue would coerce things we dont want coerced
+          const coercedArgValue = coerceInputValue(args[definedArg.name], definedArgNamedType);
+          const argValueNode = astFromValue(coercedArgValue, definedArgNamedType);
+          targetRootFieldArguments.push({
+            kind: Kind.ARGUMENT,
+            name: { kind: Kind.NAME, value: definedArg.name },
+            value: argValueNode
+          });
+
+          if (callingResolverArgs.length > 0) {
+            // if the calling resolver args has a matching argument (same name)
+            // remove it so that user provided args "override"
+            const matchingArgIdx = callingResolverArgs.findIndex((argNode) => {
+              return argNode.name.value === definedArg.name;
+            });
+            if (matchingArgIdx !== -1) {
+              callingResolverArgs.splice(matchingArgIdx, 1);
+            }
+          }
+        }
+      }
+      // append any remaining calling resolver args
+      targetRootFieldArguments.push(...callingResolverArgs);
+    }
+  }
 
   const targetRootFieldNode = {
     kind: Kind.FIELD,
-    arguments: newArgs,
+    arguments: targetRootFieldArguments,
     name: { kind: Kind.NAME, value: targetRootField },
     selectionSet: { kind: Kind.SELECTION_SET, selections }
   };
@@ -101,6 +166,8 @@ const createSubOperationDocument = function (targetRootField, subPath, info) {
  * calling resolver
  * @param {string} [options.subPath] - a dot separated string to limit the 
  * delegated selection set to a given path in the calling resolver's return type
+ * @param {object} [options.args] - an object literal whose keys/values are 
+ * passed as args to the delegatee's target field resolver.
  * @returns the result of the delegated operation to the targetRootField with
  * any errors merged into the result at their given path
  */
@@ -109,7 +176,8 @@ const delegateToComponent = async function (component, options) {
     subPath,
     contextValue,
     info,
-    targetRootField
+    targetRootField,
+    args = {}
   } = options;
 
   if (!contextValue) {
@@ -125,7 +193,7 @@ const delegateToComponent = async function (component, options) {
     targetRootField = info.fieldName;
   }
 
-  const document = createSubOperationDocument(targetRootField, subPath, info);
+  const document = createSubOperationDocument(component, targetRootField, args, subPath, info);
 
   debug(`delegating ${print(document)} to ${component.name}`);
 


### PR DESCRIPTION
summary of args functionality:

before:
unconditionally passing the calling resolver's args to the target root field in the sub operation.

after:
* we inspect the arguments of the target root field
* if the target root field has arguments:
  * pass the calling resolver arguments if present (this path is taken for automatic proxying)
  * pass user provided args whose name/coerced JS type match the target root field's arg name/type - these user provided args will override the calling resolver's args if the names match

The overall idea is that - preserve and pass all calling resolver's args if the target root field has args. Otherwise, override any matching calling resolver args with user provided args (if provided)

I think this approach is a fair trade between performance and cleanliness. Doing a lightweight introspection on the target root field's args to see if and what we should pass as arguments seems like a good trade off to simply passing args unconditionally from the calling resolver.