### PR TITLE
properly proxy subscriptions via delegateToComponent (1.x)

### DIFF
--- a/lib/delegate.js
+++ b/lib/delegate.js
@@ -1,4 +1,4 @@
-const { Kind, execute, isAbstractType, getNamedType, print } = require('graphql');
+const { Kind, execute, subscribe, isAbstractType, getNamedType, print } = require('graphql');
 const deepSet = require('lodash.set');
 const debug = require('debug')('graphql-component:delegate');
 
@@ -129,26 +129,63 @@ const delegateToComponent = async function (component, options) {
 
   debug(`delegating ${print(document)} to ${component.name}`);
 
-  let { data, errors = [] } = await execute({
-    document, 
-    schema: component.schema, 
-    rootValue: info.rootValue, 
-    contextValue, 
+  if (info.operation.operation === 'query' || info.operation.operation === 'mutation') {
+    let { data, errors = []} = await execute({
+      document, 
+      schema: component.schema, 
+      rootValue: info.rootValue, 
+      contextValue, 
+      variableValues: info.variableValues
+    });
+
+    if (!data) {
+      data = {};
+    }
+    
+    if (errors.length > 0) {
+      for (const error of errors) {
+        deepSet(data, error.path, error);
+      }
+    }
+
+    return data[targetRootField];
+  }
+
+  const result = await subscribe({
+    document,
+    schema: component.schema,
+    rootValue: info.rootValue,
+    contextValue,
     variableValues: info.variableValues
   });
 
-  // data can be completely null and destructuring defaults only apply to undefined
-  if (!data) {
-    data = {};
-  }
-  
-  if (errors.length > 0) {
-    for (const error of errors) {
-      deepSet(data, error.path, error);
+  if (Symbol.asyncIterator in result) {
+    return {
+      async next() {
+        const nextResult = await result.next();
+        if (nextResult.done) {
+          return nextResult;
+        }
+
+        let { value: { data, errors = []}} = nextResult;
+
+        if (!data) {
+          data = {};
+        }
+
+        if (errors.length > 0) {
+          for (const error of errors) {
+            deepSet(data, error.path, error);
+          }
+        }
+
+        return { done: false, value: { [targetRootField]: nextResult.value.data[targetRootField]}};
+      },
+      [Symbol.asyncIterator]() {
+        return this;
+      }
     }
   }
-
-  return data[targetRootField];
 };
 
 module.exports = { delegateToComponent };

--- a/lib/resolvers.js
+++ b/lib/resolvers.js
@@ -141,7 +141,9 @@ const createProxyResolvers = function (component, resolvers) {
         proxyResolvers[rootType][field] = resolver;
         continue;
       }
-      proxyResolvers[rootType][field] = createProxyResolver(component, rootType, field);
+      proxyResolvers[rootType][field] = (rootType === 'Subscription') ? {
+        subscribe: createProxyResolver(component, rootType, field)
+      } : createProxyResolver(component, rootType, field);
     }
   }
 


### PR DESCRIPTION
@dmicoud came across a bug when trying out subscriptions where the subscribe resolver function was not being executed and thus we were receiving an error related to subscribe being required to return an asyncIterable.

This fixes the above by setting up the proper proxying mechanism for an incoming graphql `subscription`