### PR TITLE
tweak merging errors to propagate correct error in non-null situations

### DIFF
--- a/lib/delegate.js
+++ b/lib/delegate.js
@@ -89,6 +89,26 @@ const createSubOperationDocument = function (targetRootField, subPath, info) {
 }
 
 /**
+ * merges errors in the input errors array into data based on the error path
+ * @param {object} data - the data portion of a graphql result 
+ * @param {Array<object>} errors - the errors portions of a graphql result
+ * @returns - nothing - modifies data parameter by reference 
+ */
+const mergeErrors = function (data, errors) {
+  for (const error of errors) {
+    const { path } = error;
+    const mergePath = [];
+    for (const segment of path) {
+      mergePath.push(segment);
+      if (!data[segment]) {
+        break;
+      }
+    }
+    deepSet(data, mergePath, error);
+  }
+}
+
+/**
  * executes (delegates) a graphql operation on the input component's schema
  * @param {GraphQLComponent} component - the component to delegate execution to
  * @param {object} options - an options object to customize the delegated 
@@ -143,9 +163,7 @@ const delegateToComponent = async function (component, options) {
     }
     
     if (errors.length > 0) {
-      for (const error of errors) {
-        deepSet(data, error.path, error);
-      }
+      mergeErrors(data, errors);
     }
 
     return data[targetRootField];
@@ -174,9 +192,7 @@ const delegateToComponent = async function (component, options) {
         }
 
         if (errors.length > 0) {
-          for (const error of errors) {
-            deepSet(data, error.path, error);
-          }
+          mergeErrors(data, errors);
         }
 
         return { done: false, value: { [targetRootField]: nextResult.value.data[targetRootField]}};
@@ -188,4 +204,4 @@ const delegateToComponent = async function (component, options) {
   }
 };
 
-module.exports = { delegateToComponent };
+module.exports = { delegateToComponent, mergeErrors };

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,8 +11,8 @@ const { getImportedTypes } = require('./types');
 const { buildFragments } = require('./fragments');
 const { mergeDirectives, getImportedDirectives } = require('./directives');
 const { createDataSourceInjection } = require('./datasource');
+const { mergeErrors: merge} = require('./delegate');
 const cuid = require('cuid');
-const deepSet = require('lodash.set');
 
 const debug = require('debug')('graphql-component:schema');
 
@@ -109,9 +109,7 @@ class GraphQLComponent {
       }
       //Maps errors on to the result object
       if (errors.length > 0) {
-        for (const error of errors) {
-          deepSet(data, error.path, error);
-        }
+        merge(data, errors);
       }
 
       return data;


### PR DESCRIPTION
When we merge errors - instead of blindly merging at the given path in the error - traverse the path and check the data at each segment. If a given segment is null in the data, merge at that current path instead of potentially deeper. 

This yields propagation of errors to the "outer" graphql execution regardless of the order that fields are encountered by that "outer" graphql execution