### PR TITLE
Remove resolver proxying (2.x)

### DIFF
--- a/lib/delegate/__tests__.js
+++ b/lib/delegate/__tests__.js
@@ -3,115 +3,6 @@ const gql = require('graphql-tag');
 const graphql = require('graphql');
 const GraphQLComponent = require('../');
 
-Test('integration - composite automatically delegates to root primitive field via delegateToComponent', async (t) => {
-
-  t.plan(1);
-
-  const composite = new GraphQLComponent({
-    imports: [
-      new GraphQLComponent({
-        types: `
-          type Test {
-            value: Boolean
-          }
-          type Query {
-            test: Test
-          }
-        `,
-        resolvers: {
-          Query: {
-            test() {
-              return {
-                value: true
-              }
-            }
-          }
-        }
-      })
-    ]
-  });
-
-  const { data } = await graphql.execute({
-    document: gql`query { test { value } }`,
-    schema: composite.schema,
-    rootValue: undefined,
-    contextValue: {}
-  });
-  
-  t.equal(data.test.value, true, 'resolved');
-});
-
-Test('integration - composite automatically delegates subscription', async (t) => {
-  const component = new GraphQLComponent({
-    imports: [
-      new GraphQLComponent({
-        types: [
-          `
-            type Post {
-              id: ID
-              content: String
-            }
-
-            type Query {
-              postById(id: ID): Post
-            }
-
-            type Subscription {
-              postAdded: Post
-            }
-          `
-        ],
-        resolvers: {
-          Query: {
-            postById() {
-              return { id: 1, content: 'hello' };
-            }
-          },
-          Subscription: {
-            postAdded: {
-              subscribe() {
-                return {
-                  [Symbol.asyncIterator]() {
-                    return {
-                      async next() {
-                        return { done: false, value: { postAdded: { id: 2, content: 'foobar'}}};
-                      }
-                    };
-                  }
-                }
-              }
-            }
-          }
-        }
-      })
-    ]
-  });
-
-  const document = gql`
-    subscription {
-      postAdded {
-        id
-        content
-      }
-    }
-  `
-  // graphql.subscribe would ultimately be called by servers such as Apollo Server instead of graphql.execute
-  const result = await graphql.subscribe({
-    document,
-    schema: component.schema,
-    rootValue: undefined,
-    contextValue: {}
-  });
-
-  // simulate pulling from the async iterator (normally this would be triggered by pubsub)
-  for await (const res of result) {
-    t.deepEquals(res.data, { postAdded: { id: '2', content: 'foobar' }}, 'subscription result resolved');
-    // prevent infinite loop since the source of async iterator never returns a { done: true, value: undefined }
-    break;
-  }
-  t.end();
-});
-
 Test('contextValue not passed to delegateToComponent', async (t) => {
   const primitive = new GraphQLComponent({
     types: `
@@ -800,241 +691,147 @@ Test('composite component delegates from non-root type resolver to primitive com
   t.end();
 });
 
-Test('delegateToComponent with errors', async (t) => {
-  const component = new GraphQLComponent({
-    imports: [
-      new GraphQLComponent({
-        types: `
-          type Test {
-            value: Boolean
-            err: Boolean
-          }
-          type Query {
-            test: Test
-          }
-        `,
-        resolvers: {
-          Query: {
-            test() {
-              return {
-                value: true,
-                err: true
+Test('delegateToComponent - nested abstract type is resolved without error', async (t) => {
+  let resolveTypeCount = 0;
+  const primitive = new GraphQLComponent({
+    types: `
+      type Query {
+        thingsById(id: ID): ThingsConnection
+      }
+
+      type ThingsConnection {
+        edges: [ThingEdge]
+      }
+
+      type ThingEdge {
+        node: Thing
+      }
+
+      interface Thing {
+        id: ID
+      }
+
+      type Book implements Thing {
+        id: ID
+        title: String
+      }
+
+      type Mug implements Thing {
+        id: ID
+        material: String
+      }
+    `,
+    resolvers: {
+      Query: {
+        thingsById() {
+          return {
+            edges: [
+              {
+                node: {
+                  id: 1,
+                  title: 'A tale of two cities'
+                }
+              },
+              {
+                node: {
+                  id: 2,
+                  material: 'ceramic'
+                }
               }
+            ]
+          }
+        }
+      },
+      Thing: {
+        __resolveType(result) {
+          resolveTypeCount += 1;
+          if (result.title) {
+            return 'Book'
+          }
+          else if (result.material) {
+            return 'Mug'
+          }
+        }
+      }
+    }
+  });
+
+  const composite = new GraphQLComponent({
+    types: `
+      type Query {
+        foo: Foo
+      }
+
+      type Foo {
+        things: ThingsConnection
+      }
+    `,
+    resolvers: {
+      Query: {
+        async foo(_root, _args, context, info) {
+          const result = await GraphQLComponent.delegateToComponent(primitive, {
+            targetRootField: 'thingsById',
+            info,
+            contextValue: context,
+            subPath: 'things'
+          });
+          return {things: result};
+        }
+      }
+    },
+    imports: [primitive]
+  });
+
+  const document = gql`
+    query {
+      foo {
+        things {
+          edges {
+            node {
+              id
+              ... on Book {
+                title
+              }
+              ... on Mug {
+                material
+              }
+            }
+          }
+        }
+      }
+    }
+  `
+
+  const { data, errors } = await graphql.execute({
+    document,
+    schema: composite.schema,
+    contextValue: {}
+  });
+  const expectedResult = {
+    foo: {
+      things: {
+        edges: [
+          {
+            node: {
+              id: '1',
+              title: 'A tale of two cities'
             }
           },
-          Test: {
-            err(_) {
-              if (_.err) {
-                throw new Error('error');
-              }
+          {
+            node: {
+              id: '2',
+              material: 'ceramic'
             }
           }
-        }
-      })
-    ]
-  });
-
-  const document = gql`
-    query { 
-      foo: test { value, err } 
-      bar: test { value }
-    }`;
-
-  const { data, errors } = await graphql.execute({
-    document,
-    schema: component.schema,
-    rootValue: undefined,
-    contextValue: {}
-  });
-
-  t.equal(data.foo.value, true, 'resolved alias 1');
-  t.equal(data.bar.value, true, 'resolved alias 2');
-  t.ok(errors && errors.length > 0, 'got error');
-  t.end();
-});
-
-Test('delegateToComponent - return type is not nullable and error occurs', async (t) => {
-  const component = new GraphQLComponent({
-    imports: [
-      new GraphQLComponent({
-        types: `
-          type Test {
-            value: Boolean
-          }
-          type Query {
-            test: Test!
-          }
-        `,
-        resolvers: {
-          Query: {
-            test() {
-              throw new Error('some error');
-            }
-          }
-        }
-      })
-    ]
-  });
-
-  const document = gql`
-    query { 
-      test {
-        value
+        ]
       }
-    }`;
-
-  const { data, errors } = await graphql.execute({
-    document,
-    schema: component.schema,
-    rootValue: undefined,
-    contextValue: {}
-  });
-
-  t.equal(data, null, 'data is null');
-  t.equal(errors.length, 1, '1 error returned');
-  t.equal(errors[0].message, 'some error', 'error message is error from resolver that threw');
-
+    }
+  }
+  t.deepEquals(data, expectedResult, 'data is resolved as expected');
+  t.equals(resolveTypeCount, 2, '__resolveType called once per item as expected');
+  t.notOk(errors, 'no errors');
   t.end();
 })
-
-Test('delegateToComponent - return type is abstract (__typename not requested)', async (t) => {
-  let resolveTypeCallCount = 0;
-  const child = new GraphQLComponent({
-    types: `
-      type Query {
-        things: [Thing]
-      }
-      interface Thing {
-        id: ID
-      }
-      type Person implements Thing {
-        id: ID
-        name: String
-      }
-      type Animal implements Thing {
-        id: ID
-        someField: Int
-      }
-    `,
-    resolvers: {
-      Query: {
-        things() {
-          return [
-            {
-              id: '1',
-              name: 'Joe Smith'
-            }
-          ]
-        }
-      },
-      Thing: {
-        __resolveType(parent) {
-          resolveTypeCallCount = resolveTypeCallCount + 1;
-          if (parent.name) {
-            return 'Person';
-          }
-          return 'Animal';
-        }
-      }
-    }
-  });
-
-  const parent = new GraphQLComponent({
-    imports: [
-      child
-    ]
-  });
-
-  const result = await graphql.execute({
-    document: gql`
-      query {
-        things {
-          id
-          ... on Person {
-            name
-          }
-        }
-      }
-    `,
-    schema: parent.schema,
-    contextValue: {}
-  });
-
-  t.deepEquals(result.data.things, [{ id: '1', name: 'Joe Smith' }], 'interface type resolved');
-  t.equals(resolveTypeCallCount, 1, '__resolveType called in child once per item in list');
-  t.notOk(result.errors, 'no errors');
-  t.end();
-});
-
-Test('delegateToComponent - return type is abstract (__typename requested)', async (t) => {
-  let resolveTypeCallCount = 0;
-  const child = new GraphQLComponent({
-    types: `
-      type Query {
-        things: [Thing]
-      }
-      interface Thing {
-        id: ID
-      }
-      type Person implements Thing {
-        id: ID
-        name: String
-      }
-      type Animal implements Thing {
-        id: ID
-        someField: Int
-      }
-    `,
-    resolvers: {
-      Query: {
-        things() {
-          return [
-            {
-              id: '1',
-              name: 'Joe Smith'
-            }
-          ]
-        }
-      },
-      Thing: {
-        __resolveType(parent) {
-          resolveTypeCallCount = resolveTypeCallCount + 1;
-          if (parent.name) {
-            return 'Person';
-          }
-          return 'Animal';
-        }
-      }
-    }
-  });
-
-  const parent = new GraphQLComponent({
-    imports: [
-      child
-    ]
-  });
-
-  const result = await graphql.execute({
-    document: gql`
-      query {
-        things {
-          id
-          ... on Person {
-            name
-          },
-          __typename
-        }
-      }
-    `,
-    schema: parent.schema,
-    contextValue: {}
-  });
-
-  t.deepEquals(result.data.things, [{ id: '1', name: 'Joe Smith', __typename: 'Person' }], 'interface type resolved (including requested __typename)');
-  t.equals(resolveTypeCallCount, 1, '__resolveType called in child once per item in list');
-  t.notOk(result.errors, 'no errors');
-  t.end();
-});
 
 Test('delegateToComponent - calling resolver arg is not passed when target root field does not have matching arg', async (t) => {
   const reviews = new GraphQLComponent({
@@ -1567,4 +1364,151 @@ Test('delegateToComponent - target field non-nullable arg is not passed', async 
   t.end();
 });
 
+Test('delegateToComponent - with errors', async (t) => {
+  const primitive = new GraphQLComponent({
+    types: `
+      type Query {
+        foo: Foo
+      }
+
+      type Foo {
+        a: String!
+        b: String!
+      }
+    `,
+    resolvers: {
+      Query: {
+        foo() {
+          return { a: 'a', b: null };
+        }
+      }
+    }
+  });
+
+  const composite = new GraphQLComponent({
+    types: `
+      type Query {
+        bar: Foo
+      }
+
+      type Foo {
+        c: String
+      }
+    `,
+    resolvers: {
+      Query: {
+        async bar(_root, _args, context, info) {
+          return GraphQLComponent.delegateToComponent(primitive, {
+            targetRootField: 'foo',
+            contextValue: context,
+            info
+          });
+        }
+      },
+      Foo: {
+        c() {
+          return 'c';
+        }
+      }
+    },
+    imports: [primitive]
+  });
+
+  const document = gql`
+    query {
+      abc: bar {
+        a
+        b
+        c
+      }
+      bca: bar {
+        b
+        c
+        a
+      }
+    }
+  `;
+
+  const result = await graphql.execute({
+    document,
+    schema: composite.schema,
+    contextValue: {}
+  });
+  t.equal,(result.data.abc, null, 'abc query resolves as expected');
+  t.equal(result.data.bca, null, 'bca query resolves as expected');
+  t.equal(result.errors.length, 2, '2 errors returned');
+  t.equal(result.errors[0].message, result.errors[1].message, 'errors are equal (Foo.b not nullable) regardless of differing selection set ordering');
+  t.end();
+});
+
+Test('delegateToComponent - with errors - delegate graphql data result is completely null (return type of target field is not nullable)', async (t) => {
+  const primitive = new GraphQLComponent({
+    types: `
+      type Query {
+        foo: Foo!
+      }
+
+      type Foo {
+        a: String!
+        b: String!
+      }
+    `,
+    resolvers: {
+      Query: {
+        foo() {
+          return { a: 'a', b: null };
+        }
+      }
+    }
+  });
+
+  const composite = new GraphQLComponent({
+    types: `
+      type Query {
+        bar: Foo
+      }
+
+      type Foo {
+        c: String
+      }
+    `,
+    resolvers: {
+      Query: {
+        async bar(_root, _args, context, info) {
+          return GraphQLComponent.delegateToComponent(primitive, {
+            targetRootField: 'foo',
+            contextValue: context,
+            info
+          });
+        }
+      },
+      Foo: {
+        c() {
+          return 'c';
+        }
+      }
+    },
+    imports: [primitive]
+  });
+
+  const document = gql`
+    query {
+      bar {
+        a
+        b
+        c
+      }
+    }
+  `;
+
+  const result = await graphql.execute({
+    document,
+    schema: composite.schema,
+    contextValue: {}
+  });
+  t.equal(result.data.bar, null, 'query resolves as expected');
+  t.equal(result.errors.length, 1, '1 error returned');
+  t.equal(result.errors[0].message, 'Cannot return null for non-nullable field Foo.b.', 'expected error is propagated regardless of completely null delegate result');
+  t.end();
+});
 

--- a/lib/delegate/index.js
+++ b/lib/delegate/index.js
@@ -1,5 +1,17 @@
 
-const { Kind, execute, subscribe, isAbstractType, getNamedType, print, astFromValue, coerceInputValue } = require('graphql');
+const { 
+  Kind,
+  execute,
+  subscribe,
+  isAbstractType,
+  getNamedType,
+  print,
+  astFromValue,
+  coerceInputValue,
+  TypeInfo,
+  visit,
+  visitWithTypeInfo
+} = require('graphql');
 const deepSet = require('lodash.set');
 const debug = require('debug')('graphql-component:delegate');
 
@@ -38,7 +50,7 @@ const getSelectionsForSubPath = function(path, selections) {
 }
 
 const createSubOperationDocument = function (component, targetRootField, args, subPath, info) {
-  
+
   // grab the selections starting at the calling resolver forward
   let selections = [];
   for (const fieldNode of info.fieldNodes) {
@@ -49,14 +61,6 @@ const createSubOperationDocument = function (component, targetRootField, args, s
 
   // reduce the selection set to the specified sub path if provided
   selections = getSelectionsForSubPath(subPath, selections);
-
-  // add in a top level __typename selection if the calling resolver's return type is Abstract
-  if (isAbstractType(getNamedType(info.returnType))) {
-    selections.push({
-      kind: Kind.FIELD,
-      name: { kind: Kind.NAME, value: '__typename' }
-    });
-  }
 
   let targetRootTypeFields;
   if (info.operation.operation === 'query') {
@@ -147,10 +151,59 @@ const createSubOperationDocument = function (component, targetRootField, args, s
   for (const [, fragmentDefinition] of Object.entries(info.fragments)) {
     definitions.push(fragmentDefinition);
   }
-  return {
-    kind: Kind.DOCUMENT,
-    definitions
-  };
+
+  const document = { kind: Kind.DOCUMENT, definitions };
+  const schemaConfig = component.schema.toConfig();
+  // only perform the below traversal if the delegatee's schema has an
+  // abstract type that is implemented
+  if (schemaConfig.types.some((type) => isAbstractType(type))) {
+    const typeInfo = new TypeInfo(component.schema);
+    // traverse the document's selection sets and add __typename to the
+    // selection set for any field that is an abstract type
+    return visit(document, visitWithTypeInfo(typeInfo, {
+      [Kind.SELECTION_SET](node) {
+        const parentType = typeInfo.getParentType();
+        let nodeSelections = node.selections;
+        if (parentType && isAbstractType(parentType)) {
+          nodeSelections = nodeSelections.concat({
+            kind: Kind.FIELD,
+            name: {
+              kind: Kind.NAME,
+              value: '__typename'
+            }
+          });
+        }
+
+        if (nodeSelections !== node.selections) {
+          return {
+            ...node,
+            selections: nodeSelections
+          }
+        }
+      }
+    }));
+  }
+  return document;
+}
+
+/**
+ * merges errors in the input errors array into data based on the error path
+ * @param {object} data - the data portion of a graphql result 
+ * @param {Array<object>} errors - the errors portions of a graphql result
+ * @returns - nothing - modifies data parameter by reference 
+ */
+const mergeErrors = function (data, errors) {
+  for (const error of errors) {
+    const { path } = error;
+    const mergePath = [];
+    for (const segment of path) {
+      mergePath.push(segment);
+      if (!data[segment]) {
+        break;
+      }
+    }
+    deepSet(data, mergePath, error);
+  }
 }
 
 /**
@@ -211,9 +264,7 @@ const delegateToComponent = async function (component, options) {
     }
     
     if (errors.length > 0) {
-      for (const error of errors) {
-        deepSet(data, error.path, error);
-      }
+      mergeErrors(data, errors);
     }
 
     return data[targetRootField];
@@ -242,9 +293,7 @@ const delegateToComponent = async function (component, options) {
         }
 
         if (errors.length > 0) {
-          for (const error of errors) {
-            deepSet(data, error.path, error);
-          }
+          mergeErrors(data, errors);
         }
 
         return { done: false, value: { [targetRootField]: nextResult.value.data[targetRootField]}};

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ const { mergeResolvers, mergeTypeDefs } = require('@graphql-tools/merge');
 const { makeExecutableSchema } = require('@graphql-tools/schema');
 const { addMocksToSchema } = require('@graphql-tools/mock');
 const { SchemaDirectiveVisitor } = require('@graphql-tools/utils');
-const { wrapResolvers } = require('./resolvers');
+const { bindResolvers } = require('./resolvers');
 const { buildDependencyTree } = require('./imports');
 const { wrapContext, createContext } = require('./context');
 const { createDataSourceInjection } = require('./datasource');
@@ -40,7 +40,7 @@ class GraphQLComponent {
 
     this._types = Array.isArray(types) ? types : [types];
 
-    this._resolvers = wrapResolvers(this, resolvers);
+    this._resolvers = bindResolvers(this, resolvers);
 
     this._imports = imports && imports.length > 0 ? imports.map((i) => GraphQLComponent.isComponent(i) ? { component: i, exclude: [] } : i) : [];
 

--- a/lib/resolvers/__tests__.js
+++ b/lib/resolvers/__tests__.js
@@ -5,11 +5,12 @@ const { GraphQLScalarType } = require('graphql');
 const {
   memoize,
   filterResolvers,
-  wrapResolvers,
-  createProxyResolver,
+  bindResolvers,
   importResolvers
 } = require('./index');
 const GraphQLComponent = require('../index');
+const graphql = require('graphql');
+const gql = require('graphql-tag');
 
 Test('memoize()', (t) => {
   t.test('memoize() a resolver function', (st) => {
@@ -252,8 +253,8 @@ Test('filterResolvers()', (t) => {
   })
 });
 
-Test('wrapResolvers()', (t) => {
-  t.test('wrap Query field resolver function', (st) => {
+Test('bindResolvers()', (t) => {
+  t.test('bind Query field resolver function', (st) => {
     const resolvers = {
       Query: {
         test() {
@@ -262,15 +263,15 @@ Test('wrapResolvers()', (t) => {
       }
     };
 
-    const wrapped = wrapResolvers({ id: 1 }, resolvers);
+    const bound = bindResolvers({ id: 1 }, resolvers);
 
-    const value = wrapped.Query.test({}, {}, {}, { parentType: 'Query', path: { key: 'test' } });
+    const value = bound.Query.test({}, {}, {}, { parentType: 'Query', path: { key: 'test' } });
 
     st.equal(value, 1, 'Query field resolver is bound');
     st.end();
   });
 
-  t.test('wrap Mutation field resolver function', (st) => {
+  t.test('bind Mutation field resolver function', (st) => {
     const resolvers = {
       Mutation: {
         test() {
@@ -279,15 +280,15 @@ Test('wrapResolvers()', (t) => {
       }
     };
 
-    const wrapped = wrapResolvers({ id: 1 }, resolvers);
+    const bound = bindResolvers({ id: 1 }, resolvers);
 
-    const value = wrapped.Mutation.test({}, {}, {}, { parentType: 'Mutation', path: { key: 'test' } });
+    const value = bound.Mutation.test({}, {}, {}, { parentType: 'Mutation', path: { key: 'test' } });
 
     st.equal(value, 1, 'Mutation field resolver is bound');
     st.end();
   });
 
-  t.test('wrap Subscription field resolver object', (st) => {
+  t.test('bind Subscription field resolver object', (st) => {
 
     const resolvers = {
       Subscription: {
@@ -297,13 +298,13 @@ Test('wrapResolvers()', (t) => {
       }
     };
 
-    const wrapped = wrapResolvers({ id: 1 }, resolvers);
+    const bound = bindResolvers({ id: 1 }, resolvers);
     // call the wrapped resolver result to assert this test case
-    wrapped.Subscription.someSub.subscribe();
+    bound.Subscription.someSub.subscribe();
     st.end();
   });
 
-  t.test('wrap an enum remap', (st) => {
+  t.test('bind an enum remap', (st) => {
     const resolvers = {
       FooBarEnumType: {
         FOO: 1,
@@ -311,12 +312,12 @@ Test('wrapResolvers()', (t) => {
       }
     }
 
-    const wrapped = wrapResolvers({id: 1}, resolvers);
-    st.equal(wrapped.FooBarEnumType.FOO, 1, 'enum remap runs through wrapResolvers() without error, left as is');
+    const bound = bindResolvers({id: 1}, resolvers);
+    st.equal(bound.FooBarEnumType.FOO, 1, 'enum remap runs through bindResolvers() without error, left as is');
     st.end();
   });
 
-  t.test('wrap non root type field resolver', (st) => {
+  t.test('bind non root type field resolver', (st) => {
     const resolvers = {
       SomeType: {
         test() {
@@ -325,15 +326,15 @@ Test('wrapResolvers()', (t) => {
       }
     };
 
-    const wrapped = wrapResolvers({ id: 1 }, resolvers);
+    const bound = bindResolvers({ id: 1 }, resolvers);
 
-    const value = wrapped.SomeType.test({}, {}, {}, { parentType: 'SomeType', path: { key: 'test' } });
+    const value = bound.SomeType.test({}, {}, {}, { parentType: 'SomeType', path: { key: 'test' } });
 
     st.equal(value, 1, 'SomeType field resolver is bound');
     st.end();
   });
 
-  t.test('wrap a custom GraphQLScalarType resolver', (st) => {
+  t.test('bind a custom GraphQLScalarType resolver', (st) => {
     const CustomScalarType = new GraphQLScalarType({
       name: 'CustomScalarType',
       description: 'foo bar custom scalar type',
@@ -347,16 +348,10 @@ Test('wrapResolvers()', (t) => {
       },
       CustomScalarType
     };
-    const wrapped = wrapResolvers({ id: 1}, resolvers);
-    st.equal(wrapped.CustomScalarType, CustomScalarType, 'wrapped reference is equal to original reference (returned as is)');
+    const bound = bindResolvers({ id: 1}, resolvers);
+    st.equal(bound.CustomScalarType, CustomScalarType, 'wrapped reference is equal to original reference (returned as is)');
     st.end();
   });
-});
-
-Test('createProxyResolver()', (t) => {
-  const resolver = createProxyResolver(undefined, 'Query', 'test');
-  t.strictEqual(resolver.__isProxy, true, 'function returned is a proxy');
-  t.end();
 });
 
 Test('importResolvers()', (t) => {
@@ -368,6 +363,7 @@ Test('importResolvers()', (t) => {
         }
         type SomeType {
           someField: String
+          anotherField: String
         }
       `,
       resolvers: {
@@ -375,13 +371,18 @@ Test('importResolvers()', (t) => {
           someQuery() {
             return { someField: 'hello' }
           }
+        },
+        SomeType: {
+          anotherField() {
+            return 'foo';
+          }
         }
       }
     });
 
     const importedResolvers = importResolvers(component);
-    st.ok(importedResolvers.Query.someQuery.__isProxy, 'Query.someQuery is a proxy');
-    st.notOk(importedResolvers.SomeType, 'non-root type (SomeType) is not imported')
+    st.ok(importedResolvers.Query.someQuery, 'Query.someQuery is imported');
+    st.ok(importedResolvers.SomeType.anotherField, 'non-root type resolver SomeType.anotherField is imported');
     st.end();
   });
 
@@ -409,12 +410,59 @@ Test('importResolvers()', (t) => {
     });
 
     const importedResolvers = importResolvers(component, [['Query', 'someOtherQuery']]);
-    st.ok(importedResolvers.Query.someQuery.__isProxy, 'Query.someQuery is a proxy');
     st.notOk(importedResolvers.Query.someOtherQuery, 'Query.someOtherQuery was excluded');
-    st.notOk(importedResolvers.SomeType, 'non-root type (SomeType) is not imported')
     st.end();
   });
 })
 
+Test('integration - importing resolvers properly handles enum remaps', async (t) => {
+  const component = new GraphQLComponent({
+    imports: [new GraphQLComponent({
+      types: `
+        type Query {
+          foo: Foo
+        }
+        
+        type Foo {
+          id: ID
+          bar: Bar
+        }
+        enum Bar {
+          GOOD
+          BAD
+        }
+      `,
+      resolvers: {
+        Query: {
+          foo() {
+            return { id: 1, bar: 'good' }
+          }
+        },
+        Bar: {
+          GOOD: 'good',
+          BAD: 'bad'
+        }
+      }
+    })]
+  });
+
+  const document = gql`
+    query {
+      foo {
+        id
+        bar
+      }
+    }
+  `
+
+  const { data, errors } = graphql.execute({
+    document,
+    schema: component.schema,
+    contextValue: {}
+  });
+  t.deepEqual(data, { foo: { id: '1', bar: 'GOOD'} }, 'schema with enum remap is resolved as expected');
+  t.notOk(errors, 'no errors');
+  t.end();
+}); 
 
 

--- a/lib/resolvers/index.js
+++ b/lib/resolvers/index.js
@@ -2,7 +2,6 @@
 
 const debug = require('debug')('graphql-component:resolver');
 const { GraphQLScalarType } = require('graphql');
-const { delegateToComponent } = require('../delegate');
 
 /**
  * memoizes resolver functions such that calls of an identical resolver (args/context/path) within the same request context are avoided
@@ -92,59 +91,76 @@ const filterResolvers = function (resolvers, excludes) {
  * @returns {Object} - an object identical in structure to the input resolver 
  * map, except with resolver function bound to the input argument bind
  */
-const wrapResolvers = function (bind, resolvers = {}) {
-  const wrapped = {};
+const bindResolvers = function (bind, resolvers = {}) {
+  const bound = {};
 
   for (const [type, fieldResolvers] of Object.entries(resolvers)) {
     if (fieldResolvers instanceof GraphQLScalarType) {
-      wrapped[type] = fieldResolvers;
+      bound[type] = fieldResolvers;
       continue;
     }
 
-    if (!wrapped[type]) {
-      wrapped[type] = {};
+    if (!bound[type]) {
+      bound[type] = {};
     }
 
     for (const [field, resolverFunc] of Object.entries(fieldResolvers)) {
-      if (wrapped[type][field]) {
+      if (bound[type][field]) {
         continue;
       }
 
       if (['Query', 'Mutation'].indexOf(type) > -1) {
         debug(`memoized ${type}.${field}`);
-        wrapped[type][field] = memoize(type, field, resolverFunc.bind(bind));
+        bound[type][field] = memoize(type, field, resolverFunc.bind(bind));
       } else {
         // for types other than Query/Mutation - conditionally bind since in
         // some cases (Subscriptions and enum remaps) resolverFunc will be 
         // an object instead of a function
-        wrapped[type][field] = typeof resolverFunc === 'function' ? resolverFunc.bind(bind) : resolverFunc;
+        bound[type][field] = typeof resolverFunc === 'function' ? resolverFunc.bind(bind) : resolverFunc;
       }
     }
   }
-  return wrapped;
+  return bound;
 };
 
 /**
- * returns a proxy function that delegates execution to the input component's 
- * schema
- * @param {Object} component - the component to delegate execution to
- * @param {String} rootType - the root type whose field resolver will be 
- * executed 
- * @param {String} fieldName - the root type field whose resolver is proxied
- * @returns {Function} - a function whose signature is a normal GraphQL 
- * resolver function but whose implementation delegates execution to the 
- * component owning the resolver's implementation
+ * wraps non root type resolvers from the input resolver map that quick returns 
+ * if __typename is detected
+ * @param {object} resolvers - the input resolver map with which non root 
+ * resolvers will be wrapped
+ * @returns {object} the resulting resolver map with non root type resolvers 
+ * wrapped
  */
-const createProxyResolver = function (component, rootType, fieldName) {
-  const proxyResolver = async function (_, args, contextValue, info) {
-    debug(`delegating ${rootType}.${fieldName} to ${component.name}`);
-    return delegateToComponent(component, { contextValue, info });
-  };
+const wrapNonRootTypeResolvers = function (resolvers) {
+  const result = {};
 
-  proxyResolver.__isProxy = true;
+  for (const [type, fieldResolvers] of Object.entries(resolvers)) {
+    if (['Query', 'Mutation', 'Subscription'].indexOf(type) === -1) {
+      if (!result[type]) {
+        result[type] = {};
+      }
+      for (const [field, resolver] of Object.entries(fieldResolvers)) {
+        // handle non-root types that are enum remaps
+        if (typeof resolver !== 'function') {
+          result[type][field] = resolver;
+        }
+        else {
+          result[type][field] = function (_, ...args) {
+            if (_.__typename) {
+              return field.startsWith('__') ? _.__typename : _[field];
+            }
+            return resolver(_, ...args);
+          }
+        }
+      }
+    }
+    else {
+      result[type] = fieldResolvers;
+    }
+  }
 
-  return proxyResolver;
-};
+  return result;
+}
 
 /**
  * returns a resolver map representing imported resolvers from the input 
@@ -156,25 +172,7 @@ const createProxyResolver = function (component, rootType, fieldName) {
  */
 const importResolvers = function (component, excludes) {
   const filteredResolvers = filterResolvers(component.resolvers, excludes);
-
-  const iterateRootTypeResolvers = function* () {
-    for (const type of Object.keys(filteredResolvers)) {
-      if (['Query', 'Mutation', 'Subscription'].indexOf(type) > -1) {
-        yield [type, component.resolvers[type]];
-      }
-    }
-  };
-
-  const resolvers = {};
-  for (const [type, fieldResolvers] of iterateRootTypeResolvers()) {
-    if (resolvers[type] === undefined) {
-      resolvers[type] = {};
-    }
-    for (const field of Object.keys(fieldResolvers)) {
-      resolvers[type][field] = type === 'Subscription' ? { subscribe: createProxyResolver(component, type, field) } : createProxyResolver(component, type, field);
-    }
-  }
-  return resolvers;
+  return wrapNonRootTypeResolvers(filteredResolvers);
 }
 
-module.exports = { memoize, filterResolvers, wrapResolvers, createProxyResolver, importResolvers, delegateToComponent };
+module.exports = { memoize, filterResolvers, bindResolvers, importResolvers};


### PR DESCRIPTION
* remove proxy resolver creation
* wrap non-root type resolvers for __typename short circuiting
* merge errors by traversing path
* add __typename to any level of the sub document where needed when delegating