### PR TITLE
handle wrapping non-root type resolvers that are an enum remap

### DIFF
--- a/lib/resolvers.js
+++ b/lib/resolvers.js
@@ -107,6 +107,11 @@ const wrapNonRootTypeResolvers = function (resolvers) {
         result[type] = {};
       }
       for (const [field, resolver] of Object.entries(fieldResolvers)) {
+        // handle non-root types that are enum remaps
+        if (typeof resolver !== 'function') {
+          result[type][field] = resolver;
+          continue;
+        }
         if (field.startsWith('__')) {
           result[type][field] = function (result, context, info, returnType) {
             if (result.__typename) {


### PR DESCRIPTION
pesky enum remapping 😛 

- when we removed proxy resolvers, and instead wrap non-root type resolvers, I forgot to handle the fact that non-root type resolvers can be an enum remap which is just an object with key/value where the value is not a function. In normal resolver cases the value is a function. This fixes that when wrapping non-root type resolvers from imports.