### PR TITLE
merge errors fix (v2)

### DIFF
--- a/lib/delegate/__tests__.js
+++ b/lib/delegate/__tests__.js
@@ -1364,7 +1364,7 @@ Test('delegateToComponent - target field non-nullable arg is not passed', async 
   t.end();
 });
 
-Test('delegateToComponent - with errors', async (t) => {
+Test('delegateToComponent - with errors (selection set order doesnt matter)', async (t) => {
   const primitive = new GraphQLComponent({
     types: `
       type Query {
@@ -1509,6 +1509,76 @@ Test('delegateToComponent - with errors - delegate graphql data result is comple
   t.equal(result.data.bar, null, 'query resolves as expected');
   t.equal(result.errors.length, 1, '1 error returned');
   t.equal(result.errors[0].message, 'Cannot return null for non-nullable field Foo.b.', 'expected error is propagated regardless of completely null delegate result');
+  t.deepEqual(result.errors[0].path, ['foo', 'b']);
   t.end();
 });
 
+Test('delegateToComponent - errors merged as expected for non-nullable list that allows nullable items', async (t) => {
+  const primitive = new GraphQLComponent({
+    types: `
+      type Query {
+        foos: [Foo]!
+      }
+
+      type Foo {
+        a: String!
+      }
+    `,
+    resolvers: {
+      Query: {
+        foos() {
+          return [ { a: 'bar'} , {}, { a: 'baz'} ];
+        }
+      }
+    }
+  });
+
+  const composite = new GraphQLComponent({
+    types: `
+      type Query {
+        bar: Bar
+      }
+
+      type Bar {
+        foos: [Foo]!
+      }
+    `,
+    resolvers: {
+      Query: {
+        async bar(_root, _args, context, info) {
+          const foos = await GraphQLComponent.delegateToComponent(primitive, {
+            info,
+            contextValue: context,
+            targetRootField: 'foos',
+            subPath: 'foos'
+          });
+          return { foos };
+        }
+      }
+    },
+    imports: [primitive]
+  });
+
+  const document = gql`
+    query {
+      bar {
+        foos {
+          a
+        }
+      }
+    }
+  `;
+
+  const result = await graphql.execute({
+    document,
+    schema: composite.schema,
+    contextValue: {}
+  });
+
+  t.deepEqual(result.data.bar.foos[0], { a: 'bar' }, 'first item of list resolved as expected');
+  t.deepEqual(result.data.bar.foos[2], { a: 'baz' }, 'third item of list resolved as expected');
+  t.equal(result.errors.length, 1, 'one error returned');
+  t.equal(result.errors[0].message, 'Cannot return null for non-nullable field Foo.a.');
+  t.deepEqual(result.errors[0].path, ['foos', 1, 'a']);
+  t.end();
+});

--- a/lib/delegate/index.js
+++ b/lib/delegate/index.js
@@ -12,7 +12,8 @@ const {
   visit,
   visitWithTypeInfo
 } = require('graphql');
-const deepSet = require('lodash.set');
+const set = require('lodash.set');
+const get = require('lodash.get');
 const debug = require('debug')('graphql-component:delegate');
 
 /**
@@ -195,14 +196,14 @@ const createSubOperationDocument = function (component, targetRootField, args, s
 const mergeErrors = function (data, errors) {
   for (const error of errors) {
     const { path } = error;
-    const mergePath = [];
-    for (const segment of path) {
-      mergePath.push(segment);
-      if (!data[segment]) {
+    let depth = 1;
+    while (depth <= path.length) {
+      if (!get(data, path.slice(0, depth))) {
         break;
       }
+      depth++;
     }
-    deepSet(data, mergePath, error);
+    set(data, path.slice(0, depth), error);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "cuid": "^2.1.8",
     "debug": "^4.1.1",
     "graphql-tools": "^6.0.10",
+    "lodash.get": "^4.4.2",
     "lodash.set": "^4.3.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
I realized during some debugging that `mergeErrors` had a minor bug. When traversing the path to check for nulls, it was checking `data` for an each individual segment which only works when path is length 1 😞 . This fixes the merge errors algorithm to check data at each step of the path traversal so that errors are accurately merged (Test case was added for merging an error into a list since that is how the bug was discovered). 