### PR TITLE
merge errors fix (v1)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,8 @@ const { buildFragments } = require('./fragments');
 const { mergeDirectives, getImportedDirectives } = require('./directives');
 const { createDataSourceInjection } = require('./datasource');
 const cuid = require('cuid');
-const deepSet = require('lodash.set');
+const set = require('lodash.set');
+const get = require('lodash.get');
 
 const debug = require('debug')('graphql-component:schema');
 
@@ -109,14 +110,14 @@ class GraphQLComponent {
       if (errors.length > 0) {
         for (const error of errors) {
           const { path } = error;
-          const mergePath = [];
-          for (const segment of path) {
-            mergePath.push(segment);
-            if (!data[segment]) {
+          let depth = 1;
+          while (depth <= path.length) {
+            if (!get(data, path.slice(0, depth))) {
               break;
             }
+            depth++;
           }
-          deepSet(data, mergePath, error);
+          set(data, path.slice(0, depth), error);
         }
       }
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "graphql-tag-pluck": "^0.8.7",
     "graphql-toolkit": "^0.5.0",
     "graphql-tools": "^4.0.5",
+    "lodash.get": "^4.4.2",
     "lodash.set": "^4.3.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
same fix as it applies to 2.x - the algorithm for traversing the path to determine where to merge an error had a small bug (it wasn't considering the entire traversed path when checking for null). 