### PR TITLE
directive importing

### DIFF
--- a/lib/imports/__tests__.js
+++ b/lib/imports/__tests__.js
@@ -1,183 +1,320 @@
 'use strict';
 
 const Test = require('tape');
-// TODO: test namespaceDirectives
-const { buildDependencyTree, filterTypes, /*namespaceDirectives*/ } = require('./index');
-const { buildASTSchema } = require('graphql');
-const Gql = require('graphql-tag')
+const GraphQLComponent = require('../index');
+const { buildDependencyTree, filterTypes } = require('./index');
+const { buildASTSchema, execute } = require('graphql');
+const gql = require('graphql-tag');
+const { SchemaDirectiveVisitor } = require('graphql-tools');
 
-Test('buildDependencyTree', (t) => {
-  t.plan(6);
-
-  const tree = {
-    id: 3,
-    types: [
-      `
-      type C { 
+Test('buildDependencyTree - ordering', (t) => {
+  const tree = new GraphQLComponent({
+    types: `
+      type A {
         val: String
       }
-      type Query { 
-        c: C 
+
+      type Query {
+        a: A
       }
-      `
-    ],
+    `,
     resolvers: {
-      Query: { c() {} }
+      Query: {
+        a() {}
+      }
     },
     imports: [
-      {
-        component: {
-          id: 2,
-          types: [
-            `
-            type B { 
+      new GraphQLComponent({
+        types: `
+          type B {
+            val: String
+          }
+
+          type Query {
+            a: A
+          }
+        `,
+        resolvers: {
+          Query: {
+            b(){}
+          }
+        },
+        imports: [new GraphQLComponent({
+          types: `
+            type C {
               val: String
             }
-            type Query { 
-              b: B
+
+            type Query {
+              c: C
             }
-            `
-          ],
+          `,
           resolvers: {
-            Query: { b() {} }
-          },
-          imports: [
-            {
-              component: {
-                id: 1,
-                types: [
-                  `
-                  type A { 
-                    val: String
-                  }
-                  type Query { 
-                    a: A 
-                  }
-                  `
-                ],
-                resolvers: {
-                  Query: { a() {} }
-                },
-                imports: []
-              }
+            Query: {
+              c(){}
             }
-          ]
-        }
-      }
+          }
+        })]
+      })
     ]
-  };
+  });
 
   const { importedTypes, importedResolvers } = buildDependencyTree(tree);
+ 
+  t.equal(importedTypes.length, 3, '3 imported types');
+  t.equal(importedResolvers.length, 3, '3 imported resolvers');
 
-  t.equal(importedTypes.length, 2, '2 imported types');
-  t.equal(importedResolvers.length, 2, '2 imported resolvers');
+  t.equal(importedTypes[0].definitions[0].name.value, 'C', 'C type ordered properly');
+  t.equal(importedTypes[1].definitions[0].name.value, 'B', 'B type ordered properly');
+  t.equal(importedTypes[2].definitions[0].name.value, 'A', 'A type ordered properly');
 
-  t.equal(importedTypes[0].definitions[0].name.value, 'B', 'B type ordered properly');
-  t.equal(importedTypes[1].definitions[0].name.value, 'A', 'A type ordered properly');
-
-  t.ok(importedResolvers[0].Query.b, 'B resolvers ordered properly');
-  t.ok(importedResolvers[1].Query.a, 'A resolvers ordered properly');
+  t.ok(importedResolvers[0].Query.c, 'c resolvers ordered properly');
+  t.ok(importedResolvers[1].Query.b, 'b resolvers ordered properly');
+  t.ok(importedResolvers[2].Query.a, 'a resolvers ordered properly');
+  t.end();
 });
 
-Test('type utilities', (t) => {
+Test('buildDependencyTree - directive not implemented', (t) => {
+  const root = new GraphQLComponent({
+    types: `
+      directive @foo on FIELD_DEFINITION
 
-  t.test('exclude', (t) => {
+      type Query {
+        a: A @foo
+      }
 
-    t.plan(4);
-
-    const component = {
-      _importedTypes: [Gql`
-        type B {
-          value: String
-        }
-        type Query {
-          b: B
-        }
-      `],
-      _types: [Gql`
-        type A {
-          value: String
-        }
-        type Query {
-          a: A
-        }
-      `]
-    };
-
-    const types = filterTypes([...component._types, ...component._importedTypes], [['Query', 'b']]);
-    
-    const schemaA = buildASTSchema(types[0]);
-
-    t.ok(schemaA.getType('A').getFields().value, `the "A" type exists in component's schema`);
-    t.ok(schemaA.getQueryType().getFields().a, `the "a" query exists in component's schema`);
-
-    const schemaB = buildASTSchema(types[1])
-    
-    t.ok(schemaB.getType('B').getFields().value, `the "B" type exists in imported component's schema`);
-    t.notOk(schemaB.getQueryType(), `the "Query" type does not exist in imported component's schema because all of its fields have been removed`);
+      type A {
+        value: String
+      }
+    `,
+    resolvers: {
+      Query: {
+        a(){}
+      }
+    }
   });
 
-  t.test('exclude all', (t) => {
-
-    t.plan(3);
-
-    const component = {
-      _importedTypes: [],
-      _types: [Gql`
-        type A {
-          value: String
-        }
-        type Query {
-          a: A
-        }
-        type Mutation {
-          a: A
-        }
-      `]
-    };
-
-    const types = filterTypes(component._types, [['*']]);
-    const schema = buildASTSchema(types[0]);
-    t.notOk(schema.getQueryType(), `the "Query" type does not exist in component's schema because all of it's fields were removed`);
-    t.notOk(schema.getMutationType(), `the "Mutation" type does not exist in component's schema because all of its fields were removed`);
-    t.ok(schema.getType('A').getFields().value, `the "A" type and its field exist in component's schema`);
-  });
-  
-  t.test('component with no Mutation and 1 Query with imported component with 2 Mutations and 1 Query, exclude 1 Mutation and 1 Query from imported component', (t) => {
-    t.plan(6);
-
-    const component = {
-      _importedTypes: [Gql`
-        type B {
-          value: String
-        }
-        type Query {
-          b: B
-        }
-        type Mutation {
-          b1: String
-          b2: String
-        }
-      `],
-      _types: [Gql`
-        type A {
-          value: String
-        }
-        type Query {
-          a: A
-        }
-      `]
-    };
-
-    const types = filterTypes([...component._types, ...component._importedTypes], [['Mutation', 'b1'], ['Query', 'b']]);
-    const schemaA = buildASTSchema(types[0]);
-    t.ok(schemaA.getType('A').getFields().value, `the "A" type exists in component's schema`);
-    t.ok(schemaA.getQueryType().getFields().a, `the "a" query exists in component's schema`);
-
-    const schemaB = buildASTSchema(types[1])
-    t.ok(schemaB.getType('B').getFields().value, `the "B" type exists in imported component's schema`);
-    t.notOk(schemaB.getQueryType(), `the "Query" type does not exist in imported component's schema because all of its fields were removed`);
-    t.notOk(schemaB.getMutationType().getFields().b1, `the "b1" mutation does not exist in imported component's schema`);
-    t.ok(schemaB.getMutationType().getFields().b2, `the "b2" mutation exists in imported component's schema`);
-  });
+  try {
+    buildDependencyTree(root);
+  } catch (e) {
+    t.equals(e.message, 'GraphQLComponent defined directive: @foo but did not provide an implementation', 'error thrown with expected error message');
+  }
+  t.end();
 });
+
+Test('buildDependencyTree - components with directive collisions', (t) => {
+  const imp = new GraphQLComponent({
+    types: `
+      directive @duplicate on FIELD_DEFINITION
+
+      type Bar {
+        value: String
+      }
+
+      type Query {
+        bar: Bar @duplicate
+      }
+    `,
+    Query: {
+      bar(){}
+    },
+    directives: {
+      duplicate: class extends SchemaDirectiveVisitor {
+        visitFieldDefinition() {}
+      }
+    }
+  });
+
+  const root = new GraphQLComponent({
+    types: `
+      directive @duplicate on FIELD_DEFINITION
+      directive @foo on FIELD_DEFINITION
+
+      type Foo {
+        value: String
+      }
+
+      type Query {
+        foo: Foo @duplicate @foo
+      }
+    `,
+    resolvers: {
+      Query: {
+        foo() {}
+      }
+    },
+    imports: [imp],
+    directives: {
+      duplicate: class extends SchemaDirectiveVisitor {
+        visitFieldDefinition(){}
+      },
+      foo: class extends SchemaDirectiveVisitor {
+        visitFieldDefinition(){}
+      }
+    }
+  });
+
+  const { importedDirectives } = buildDependencyTree(root);
+  t.ok(importedDirectives['duplicate'], `root's original duplicate directive imported intact`);
+  t.ok(importedDirectives[`duplicate_${imp.id}`], `imp's conflicting directive is namespaced`);
+  t.ok(importedDirectives['foo'], `root's non-conflicting diretive imported intact`);
+  t.end();
+});
+
+Test('integration - directive collisions', (t) => {
+  let impDuplicateExecuted = 0;
+  let rootDuplicateExecuted = 0;
+  let rootFooExecuted = 0;
+  const imp = new GraphQLComponent({
+    types: `
+      directive @duplicate on FIELD_DEFINITION
+
+      type Bar {
+        value: String
+      }
+
+      type Query {
+        bar: Bar @duplicate
+      }
+    `,
+    Query: {
+      bar(){}
+    },
+    directives: {
+      duplicate: class extends SchemaDirectiveVisitor {
+        visitFieldDefinition() {
+          impDuplicateExecuted += 1;
+        }
+      }
+    }
+  });
+
+  const root = new GraphQLComponent({
+    types: `
+      directive @duplicate on FIELD_DEFINITION
+      directive @foo on FIELD_DEFINITION
+
+      type Foo {
+        value: String
+      }
+
+      type Query {
+        foo: Foo @duplicate @foo
+      }
+    `,
+    resolvers: {
+      Query: {
+        foo() {}
+      }
+    },
+    imports: [imp],
+    directives: {
+      duplicate: class extends SchemaDirectiveVisitor {
+        visitFieldDefinition(){
+          rootDuplicateExecuted += 1;
+        }
+      },
+      foo: class extends SchemaDirectiveVisitor {
+        visitFieldDefinition(){
+          rootFooExecuted += 1;
+        }
+      }
+    }
+  });
+
+  const document = gql`
+    query {
+      foo {
+        value
+      }
+      bar {
+        value
+      }
+    }
+  `;
+
+  // execute the above queries to see that the directives executed
+  execute({
+    document,
+    schema: root.schema,
+    contextValue: {}
+  });
+
+  t.equal(rootDuplicateExecuted, 1, 'root @duplicate directive executed one time as expected');
+  t.equal(rootFooExecuted, 1, 'root @duplicate directive executed one time as expected')
+  t.equal(impDuplicateExecuted, 1, 'imp @duplicate directive executed one time as expected');
+  t.end();
+});
+
+Test('filterTypes - simple exclusion', (t) => {
+  const types = gql`
+    type B {
+      value: String
+    }
+
+    type A {
+      value: String
+    }
+
+    type Query {
+      a: A
+      b: B
+    }
+  `;
+
+  const filteredTypes = filterTypes([types], [['Query', 'b']]);
+  const schema = buildASTSchema(filteredTypes[0]);
+  t.ok(schema.getType('A'), 'type A exists');
+  t.ok(schema.getType('B'), 'type B exists');
+  t.ok(schema.getType('Query').getFields().a, 'Query.a exists');
+  t.notOk(schema.getType('Query').getFields().b, 'Query.b has been excluded');
+  t.end();
+});
+
+Test('filterTypes - asterisk exclusion', (t) => {
+  const types = gql`
+    type B {
+      value: String
+    }
+
+    type A {
+      value: String
+    }
+
+    type Query {
+      a: A
+      b: B
+    }
+  `;
+
+  const filteredTypes = filterTypes([types], [['Query', '*']]);
+  const schema = buildASTSchema(filteredTypes[0]);
+  t.ok(schema.getType('A'), 'type A exists');
+  t.ok(schema.getType('B'), 'type B exists');
+  t.notOk(schema.getType('Query'), 'Query type has been completed excluded');
+  t.end();
+});
+
+Test('filterTypes - one by one exclusion', (t) => {
+  const types = gql`
+    type B {
+      value: String
+    }
+
+    type A {
+      value: String
+    }
+
+    type Query {
+      a: A
+      b: B
+    }
+  `;
+
+  const filteredTypes = filterTypes([types], [['Query', 'a'], ['Query', 'b']]);
+  const schema = buildASTSchema(filteredTypes[0]);
+  t.ok(schema.getType('A'), 'type A exists');
+  t.ok(schema.getType('B'), 'type B exists');
+  t.notOk(schema.getType('Query'), 'Query type has been completed excluded');
+  t.end();
+})

--- a/lib/imports/index.js
+++ b/lib/imports/index.js
@@ -31,10 +31,9 @@ const filterTypes  = function (types, excludes) {
   
   for (const doc of types) {
     const { definitions } = doc;
-    // iterate through the document's definitions and apply exclusions to applicable definitions.
-    // if the definition has no fields after exclusions are applied, remove the definition from the document
-    // we are iterating through the definitions backwards so that when we remove a definition the
-    // inner for loop's index calculation stays in sync
+    // iterate through the definitions backwards - such that in the case
+    // where we need to modify the definitions array itself, everything
+    // stays in sync
     for (let i = definitions.length - 1; i >= 0; --i) {
       const def = definitions[i]
       if (def.kind === 'ObjectTypeDefinition' && ['Query', 'Mutation', 'Subscription'].indexOf(def.name.value) > -1) {
@@ -56,42 +55,75 @@ const filterTypes  = function (types, excludes) {
   return types;
 };
 
-const namespaceDirectives = function (rootDirectives, id, document) {
-  const namespaceEach = function (list) {
-    for (const definition of list) {
-      if (definition.kind === 'DirectiveDefinition' || definition.kind === 'Directive') {
-        if (rootDirectives[definition.name.value]) {
-          const name = `${definition.name.value}_${id}`;
-          debug(`namespacing imported ${definition.name.value} directive as ${name}`);
-          definition.name.value = name;
+const importDirectives = function (typedefDocuments, component, importedDirectives) {
+  const { directives: componentDirectives } = component;
+  const result = {};
+
+  for (let [directiveName, directiveImplementation] of Object.entries(componentDirectives)) {
+    // conflict detected - namespace the current component's directive
+    if (importedDirectives[directiveName]) {
+      const newDirectiveName = `${directiveName}_${component.id}`;
+      for (let document of typedefDocuments) {
+        for (let definition of document.definitions) {
+          namespaceDirectiveInAST(definition, directiveName, newDirectiveName);
         }
       }
-      if (definition.directives) {
-        namespaceEach(definition.directives);
-      }
-      if (definition.fields) {
-        namespaceEach(definition.fields);
+      result[newDirectiveName] = directiveImplementation;
+    }
+    else {
+      result[directiveName] = directiveImplementation;
+    }
+  }
+
+  return result;
+}
+
+// has side effects - modifies the input astNode 
+const namespaceDirectiveInAST = function (astNode, originalDirectiveName, newDirectiveName) {
+  // base case
+  if ((astNode.kind === 'DirectiveDefinition' || astNode.kind === 'Directive') && astNode.name.value === originalDirectiveName) {
+    astNode.name.value = newDirectiveName;
+  }
+
+  if (astNode.directives && astNode.directives.length > 0) {
+    for (let directiveNode of astNode.directives) {
+      namespaceDirectiveInAST(directiveNode, originalDirectiveName, newDirectiveName);
+    }
+  }
+
+  if (astNode.fields && astNode.fields.length > 0) {
+    for (let fieldNode of astNode.fields) {
+      namespaceDirectiveInAST(fieldNode, originalDirectiveName, newDirectiveName);
+    }
+  }
+}
+
+const checkForDirectiveImplementations = function (typeDefDocuments, component) {
+  const { directives } = component;
+  for (let document of typeDefDocuments) {
+    for (let typedef of document.definitions) {
+      if (typedef.kind === 'DirectiveDefinition') {
+        if (!directives[typedef.name.value]) {
+          throw new Error(`${component.name} defined directive: @${typedef.name.value} but did not provide an implementation`);
+        }
       }
     }
-  };
-  
-  namespaceEach(document.definitions);
-
-  return document;
-};
+  }
+}
 
 const buildDependencyTree = function (root) {
   const importedTypes = [];
   const importedResolvers = [];
-  const importedMocks = []
+  const importedMocks = [];
+  let importedDirectives = {};
 
   const visited = new Set();
-  const queue = [...root.imports.map((imported) => ({ ...imported, parent: root }))]; 
+  const queue = [{component: root}];
   
   while (queue.length > 0) {
     const current = queue.shift();
 
-    const { component, exclude, parent } = current;
+    const { component, exclude } = current;
 
     if (visited.has(component.id)) {
       continue;
@@ -99,26 +131,35 @@ const buildDependencyTree = function (root) {
 
     const excludes = parseExclude(exclude);
 
-    const rootDirectives = parent.directives;
+    // import types
+    const types = filterTypes(component.types.map((type) => graphql.parse(type)), excludes);
+    importedTypes.unshift(...types);
 
-    // import types from imported component
-    const types = filterTypes(component.types.map((type) => {
-      return namespaceDirectives(rootDirectives, `${component.name}_${component.id}`, graphql.parse(type))
-    }), excludes);
-    importedTypes.push(...types);
-    
+    // import diretives
+    checkForDirectiveImplementations(types, component);
+
+    if (Object.keys(component.directives).length > 0 && Object.keys(importedDirectives).length > 0) {
+      const importedComponentDirectives = importDirectives(types, component, importedDirectives);
+      importedDirectives = { ...importedDirectives, ...importedComponentDirectives };
+    }
+    else {
+      importedDirectives = { ...importedDirectives, ...component.directives };
+    }
+
     // import resolvers from imported component
     const resolvers = importResolvers(component, excludes);
-    importedResolvers.push(resolvers);
+    importedResolvers.unshift(resolvers);
 
     // imports mocks from imported component
-    importedMocks.push(component.mocks);
-    
+    if (component.mocks) {
+      importedMocks.unshift(component.mocks);
+    }
+
     visited.add(component.id);
-    queue.push(...component.imports.map((imported) => ({ ...imported, parent: component })));
+    queue.push(...component.imports);
   }
 
-  return { importedTypes, importedResolvers, importedMocks };
+  return { importedTypes, importedResolvers, importedMocks, importedDirectives };
 };
 
-module.exports = { buildDependencyTree, filterTypes, namespaceDirectives };
+module.exports = { buildDependencyTree, filterTypes };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const graphql = require('graphql');
 const { buildFederatedSchema } = require('@apollo/federation');
 const { mergeResolvers, mergeTypeDefs } = require('@graphql-tools/merge');
 const { makeExecutableSchema } = require('@graphql-tools/schema');
@@ -94,11 +93,11 @@ class GraphQLComponent {
       return this._schema;
     }
 
-    const { importedTypes, importedResolvers, importedMocks } = buildDependencyTree(this);
+    const { importedTypes, importedResolvers, importedMocks, importedDirectives } = buildDependencyTree(this);
 
-    const typeDefs = mergeTypeDefs([...importedTypes, ...this._types.map((type) => graphql.parse(type))]);
-    const resolvers = mergeResolvers([...importedResolvers, this._resolvers]);
-    const schemaDirectives = this._directives;
+    const typeDefs = mergeTypeDefs([...importedTypes]);
+    const resolvers = mergeResolvers([...importedResolvers]);
+    const schemaDirectives = importedDirectives;
 
     const makeSchema = this._federation ? this.makeFederatedSchemaWithDirectives : makeExecutableSchema;
 
@@ -113,7 +112,7 @@ class GraphQLComponent {
     if (this._useMocks) {
       debug(`adding mocks, preserveResolvers=${this._preserveResolvers}`);
 
-      schema = addMocksToSchema({schema, mocks: Object.assign({}, this._mocks, ...importedMocks), preserveResolvers: this._preserveResolvers});
+      schema = addMocksToSchema({schema, mocks: Object.assign({}, ...importedMocks), preserveResolvers: this._preserveResolvers});
     }
 
     this._schema = schema;


### PR DESCRIPTION
update/clean up buildDependencyTree to properly import and namespace directives on collision and include processing of the root which removes/simplifies code from the schema getter

- this fixes directives in 2.x while using a similar approach as 1.x, but incorporated into the `buildDependencyTree` approach of 2.x

- added in a check for directive implementations - during the dependency tree building process - if a component defines directives in it's SDL and doesn't provide an implementation for the directive an informative error will be thrown
