### PR TITLE
correct error path in errors surfaced via delegateToComponent

### DIFF
--- a/lib/delegate/__tests__.js
+++ b/lib/delegate/__tests__.js
@@ -452,7 +452,7 @@ Test('composite component delegates from non-root type resolver to primitive com
         }
       },
       B: {
-        a(_, args, context, info) {
+        a(_, _args, context, info) {
           return GraphQLComponent.delegateToComponent(primitive, {
             contextValue: context,
             info
@@ -1688,7 +1688,9 @@ Test('delegateToComponent - target field non-nullable arg is not passed', async 
     contextValue: {}
   });
   t.deepEqual(result.data, { propertyById: { id: '1', reviews: null } }, 'property partially resolves, reviews null');
+  t.equal(result.errors.length, 1, '1 error returned')
   t.equal(result.errors[0].message, `Argument "id" of required type "ID!" was not provided.`, 'required arg error message is propagated');
+  t.deepEqual(result.errors[0].path, ['propertyById', 'reviews'], 'error path is as expected');
   t.end();
 });
 
@@ -1753,7 +1755,7 @@ Test('delegateToComponent - with errors (selection set order doesnt matter)', as
         b
         c
         a
-      }
+      },
     }
   `;
 
@@ -1765,7 +1767,9 @@ Test('delegateToComponent - with errors (selection set order doesnt matter)', as
   t.equal,(result.data.abc, null, 'abc query resolves as expected');
   t.equal(result.data.bca, null, 'bca query resolves as expected');
   t.equal(result.errors.length, 2, '2 errors returned');
-  t.equal(result.errors[0].message, result.errors[1].message, 'errors are equal (Foo.b not nullable) regardless of differing selection set ordering');
+  t.equal(result.errors[0].message, result.errors[1].message, 'error messages are equal (Foo.b not nullable) regardless of differing selection set ordering');
+  t.deepEqual(result.errors[0].path, ['abc', 'b'], 'first error has path as expected');
+  t.deepEqual(result.errors[1].path, ['bca', 'b'], 'second error has path as expected');
   t.end();
 });
 
@@ -1837,7 +1841,7 @@ Test('delegateToComponent - with errors - delegate graphql data result is comple
   t.equal(result.data.bar, null, 'query resolves as expected');
   t.equal(result.errors.length, 1, '1 error returned');
   t.equal(result.errors[0].message, 'Cannot return null for non-nullable field Foo.b.', 'expected error is propagated regardless of completely null delegate result');
-  t.deepEqual(result.errors[0].path, ['foo', 'b']);
+  t.deepEqual(result.errors[0].path, ['bar', 'b'], `error's path has expected value`);
   t.end();
 });
 
@@ -1904,13 +1908,87 @@ Test('delegateToComponent - errors merged as expected for non-nullable list that
   });
 
   t.deepEqual(result.data.bar.foos[0], { a: 'bar' }, 'first item of list resolved as expected');
+  t.deepEqual(result.data.bar.foos[1], null, 'second item is null as expected');
   t.deepEqual(result.data.bar.foos[2], { a: 'baz' }, 'third item of list resolved as expected');
   t.equal(result.errors.length, 1, 'one error returned');
   t.equal(result.errors[0].message, 'Cannot return null for non-nullable field Foo.a.');
-  t.deepEqual(result.errors[0].path, ['foos', 1, 'a']);
+  t.deepEqual(result.errors[0].path, ['bar', 'foos', 1, 'a'], `error's path has expected value`);
   t.end();
 });
 
+Test('delegateToComponent - with errors - verify error path when delegation occurs from non-root resolver', async (t) => {
+  const primitive = new GraphQLComponent({
+    types: `
+      type Query {
+        a: A
+      }
+
+      type A {
+        aField: String
+      }
+    `,
+    resolvers: {
+      Query: {
+        a() {
+          throw new Error('error retrieving A');
+        }
+      }
+    }
+  });
+
+  const composite = new GraphQLComponent({
+    types: `
+      type Query {
+        b: B
+      }
+
+      type B {
+        a: A
+        bField: String
+      }
+    `,
+    resolvers: {
+      Query: {
+        b() {
+          return { bField: 'bField' };
+        }
+      },
+      B: {
+        a(_root, _args, context, info) {
+          return GraphQLComponent.delegateToComponent(primitive, {
+            contextValue: context,
+            info,
+            subPath: 'a'
+          });
+        }
+      }
+    },
+    imports: [primitive]
+  });
+
+  const document = gql`
+    query {
+      b {
+        a {
+          aField
+        }
+        bField
+      }
+    }
+  `;
+
+  const result = await graphql.execute({
+    schema: composite.schema,
+    document,
+    contextValue: {}
+  });
+  t.equal(result.data.b.a, null, 'b.a is null as expected due to error');
+  t.equal(result.data.b.bField, 'bField', `b's field resolved as expected`);
+  t.equal(result.errors.length, 1, '1 error returned');
+  t.equal(result.errors[0].message, 'error retrieving A');
+  t.deepEqual(result.errors[0].path, ['b', 'a']);
+  t.end();
+});
 Test(`delegateToComponent - variable in outer query for type that doesn't exist in schema being delegated to`, async (t) => {
   const primitive = new GraphQLComponent({
     types: `

--- a/lib/delegate/index.js
+++ b/lib/delegate/index.js
@@ -185,19 +185,52 @@ const createSubOperationDocument = function (component, targetRootField, args, s
  * merges errors in the input errors array into data based on the error path
  * @param {object} data - the data portion of a graphql result 
  * @param {Array<object>} errors - the errors portions of a graphql result
+ * @param {GraphQLResolveInfo} info - the info object from the resolver who
+ * called delegateToComponent
  * @returns - nothing - modifies data parameter by reference 
  */
-const mergeErrors = function (data, errors) {
-  for (const error of errors) {
+const mergeErrors = function (data, errors, info) {
+  // use info to build the path tha was traversed prior to the delegateToComponent call
+  const prePath = [];
+  let curr = info.path;
+  while (curr) {
+    prePath.unshift(curr.key);
+    curr = curr.prev;
+  }
+
+  for (let error of errors) {
+    
     const { path } = error;
-    let depth = 1;
-    while (depth <= path.length) {
-      if (!get(data, path.slice(0, depth))) {
-        break;
+    // errors can occur via graphql.execute() that occur before
+    // actual execution occurs with which the error won't have a path
+    // in which case we'll just throw it and fail fast.
+    if (path) {
+      let depth = 1;
+      while (depth <= path.length) {
+        if (!get(data, path.slice(0, depth))) {
+          break;
+        }
+        depth++;
       }
-      depth++;
+
+      // merge the error in at a slice path (this is to handle nullability)
+      set(data, path.slice(0, depth), error);
+
+      // modify the error's path
+      const returnTypeASTNode = info.returnType.astNode ? info.returnType.astNode : info.returnType.ofType.astNode;
+      // if the first segment of the error path is a field on the return type
+      // of the calling resolver it will remain part of the adjusted path
+      // otherwise we will remove it since that first segment represents
+      // the resolver field we delegated to which is a detail we want to
+      // abstract away from the outer operation
+      if (!returnTypeASTNode.fields.find((field) => field.name.value === error.path[0])) {
+        error.path.shift();
+      }
+      error.path.unshift(...prePath);
     }
-    set(data, path.slice(0, depth), error);
+    else {
+      throw error;
+    }
   }
 }
 
@@ -258,9 +291,8 @@ const delegateToComponent = async function (component, options) {
     }
     
     if (errors.length > 0) {
-      mergeErrors(data, errors);
+      mergeErrors(data, errors, info);
     }
-
     return data[targetRootField];
   }
 
@@ -286,7 +318,7 @@ const delegateToComponent = async function (component, options) {
         }
 
         if (errors.length > 0) {
-          mergeErrors(data, errors);
+          mergeErrors(data, errors, info);
         }
 
         return { done: false, value: { [targetRootField]: nextResult.value.data[targetRootField]}};

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "debug": "^4.1.1",
     "graphql-tools": "^6.0.10",
     "lodash.clonedeep": "^4.5.0",
+    "lodash.clonedeepwith": "^4.5.0",
     "lodash.get": "^4.4.2",
     "lodash.set": "^4.3.2"
   },


### PR DESCRIPTION
When delegating from a resolver and an error occurs in that delegated (sub) operation the error path of that error was not complete in the sense that it starts at the root resolver being delegated to (instead of at the root of the outer operation). Callers/Requesters of GraphQL APIs that use delegate should be none-the-wiser to delegation being used, especially in the case where a UI needs to rely on an error path for null checking/error validity. 

This fixes error paths that occur in delegated operations. It starts by building the already traversed path, and appending it to the errors that bubble up from a delegated operation. It also takes into account whether or not to keep the first segment in the error path from the delegated operation since that may be a detail we want to hide (for ex: I'm delegating from a field `foo` to a field `bar`, I wouldn't necessarily want `bar` to show up in the error path because it could be excluded). To determine if the first segment in the error path should be kept - we examine the fields of the return type of the resolver who called delegateToComponent. If the first segment is one of the fields on the return type we keep it, if not we discard the first segment since our calling resolver either has the same name or we delegated to a field of a different name with which we would want to hide. 