### PR TITLE
remove forwarding of variables from outer operation to delegated oper…

### DIFF
--- a/lib/delegate/__tests__.js
+++ b/lib/delegate/__tests__.js
@@ -1910,3 +1910,86 @@ Test('delegateToComponent - errors merged as expected for non-nullable list that
   t.deepEqual(result.errors[0].path, ['foos', 1, 'a']);
   t.end();
 });
+
+Test(`delegateToComponent - variable in outer query for type that doesn't exist in schema being delegated to`, async (t) => {
+  const primitive = new GraphQLComponent({
+    types: `
+      type Query { 
+        a(aone: Int, atwo: String): A
+      }
+
+      type A {
+        aField: String
+      }
+    `,
+    resolvers: {
+      Query: {
+        a() {
+          return { aField: 'aField' };
+        }
+      }
+    }
+  });
+
+  const composite = new GraphQLComponent({
+    types: `
+      type Query {
+        b(bone: Int, btwo: C): B
+      }
+
+      type B {
+        a: A
+        bField: String
+      }
+
+      enum C {
+        CONE
+        CTWO
+      }
+    `,
+    resolvers: {
+      Query: {
+        async b(_root, args, context, info) {
+          const a = await GraphQLComponent.delegateToComponent(primitive, {
+            contextValue: context,
+            info,
+            targetRootField: 'a',
+            subPath: 'a',
+            args: {
+              aone: args.bone,
+              atwo: args.btwo
+            }
+          });
+          return { a, bField: 'bField' };
+        }
+      }
+    },
+    imports: [primitive]
+  });
+
+  const document = gql`
+    query something($first: Int, $second: C, $third: Boolean) {
+      b(bone: $first, btwo: $second) {
+        a {
+          aField
+        }
+        bField
+      }
+    }
+  `;
+
+  const result = await graphql.execute({
+    schema: composite.schema,
+    document,
+    contextValue: {},
+    variableValues: {
+      first: 1,
+      second: 'CONE',
+      third: true
+    }
+  });
+  
+  t.notOk(result.errors, 'no errors');
+  t.deepEqual(result.data.b, { a: { aField: 'aField'}, bField: 'bField' }, 'result resolved as expected');
+  t.end();
+})

--- a/lib/delegate/index.js
+++ b/lib/delegate/index.js
@@ -139,11 +139,10 @@ const createSubOperationDocument = function (component, targetRootField, args, s
   const operationDefinition = {
     kind: Kind.OPERATION_DEFINITION,
     operation: info.operation.operation,
-    selectionSet: { kind: Kind.SELECTION_SET, selections: [targetRootFieldNode]},
-    variableDefinitions: info.operation.variableDefinitions
+    selectionSet: { kind: Kind.SELECTION_SET, selections: [targetRootFieldNode]}
   };
 
-  const definitions = [operationDefinition]
+  const definitions = [operationDefinition];
   for (const [, fragmentDefinition] of Object.entries(info.fragments)) {
     definitions.push(fragmentDefinition);
   }
@@ -251,8 +250,7 @@ const delegateToComponent = async function (component, options) {
       document, 
       schema: component.schema, 
       rootValue: info.rootValue, 
-      contextValue, 
-      variableValues: info.variableValues
+      contextValue
     });
 
     if (!data) {
@@ -270,8 +268,7 @@ const delegateToComponent = async function (component, options) {
     document,
     schema: component.schema,
     rootValue: info.rootValue,
-    contextValue,
-    variableValues: info.variableValues
+    contextValue
   });
 
   if (Symbol.asyncIterator in result) {


### PR DESCRIPTION
…ation

As far as I can tell there is 0 utility to passing the variableValues/variableDefinitions from the outer operation to the inner operation (created by delegateToComponent).

The reason for removal is, we risk error by passing the variables down to the delegated schema. If there is a variable declared with a type that isn't in the schema being delegated to, graphql.execute() will throw an error since it tries to coerce the variables to the type declared.