### PR TITLE
delegate field pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To intercept resolvers with mocks execute this app with `GRAPHQL_MOCK=1` enabled
   - `dataSources` - an array of data sources instances to make available on `context.dataSources` .
   - `dataSourceOverrides` - overrides for data sources in the component tree.
   - `federation` - enable building a federated schema (default: `false`).
-- `GraphQLComponent.delegateToComponent(component, options)` - helper for delegating an operation to another component's schema and returning the GraphQL result. When called from a resolver, this function will examine the passed `info` object and will automatically forward the remaining operation selection set (or a limited subset of the selection set) to a root type field in the input component's schema.
+- `GraphQLComponent.delegateToComponent(component, options)` - helper for delegating an operation to another component's schema and returning the GraphQL result. When called from a resolver, this function will examine the passed `info` object and will automatically forward the remaining operation selection set (or a limited subset of the selection set) to a root type field in the input component's schema. This function will automatically prune out fields in the delegated selection set that are not defined in the schema (component) being delegated to.
   - `component` (instance of `GraphQLComponent`) - the component's whose schema will be the target of the delegated operation
   - `options` (`Object`)
     - `contextValue` (required) - the `context` object from resolver that calls `delegateToComponent`

--- a/lib/delegate/__tests__.js
+++ b/lib/delegate/__tests__.js
@@ -2073,7 +2073,7 @@ Test(`delegateToComponent - variable in outer query for type that doesn't exist 
   t.end();
 });
 
-Test(`delegateToComponent - variable is used in outer query as arg in non-root resolver who delegates`, async (t) => {
+Test(`delegateToComponent - variables are present in delegated selection set`, async (t) => {
   const primitive = new GraphQLComponent({
     types: `
       type Query { 
@@ -2086,9 +2086,11 @@ Test(`delegateToComponent - variable is used in outer query as arg in non-root r
     `,
     resolvers: {
       Query: {
-        a(_root, args) {
-          t.equal(args.aone, 1, 'variable from outer query is passed from non-root resolver who called delegated');
-          t.equal(args.atwo, 'hello', 'other arg is passed via delegate call')
+        a(_root, args, _context, info) {
+          t.equal(args.aone, 1, 'variable from outer query is passed from non-root resolver who called delegate');
+          t.equal(args.atwo, 1, 'variable from outer query is passed from non-root resolver who called delegate');
+          t.equal(info.operation.variableDefinitions.length, 1, 'only 1 variable definition forwarded');
+          t.equal(info.operation.variableDefinitions[0].variable.name.value, 'first', '$first variable definition is forwarded as it is only one used');
           return { aField: 'aField' };
         }
       }
@@ -2102,7 +2104,7 @@ Test(`delegateToComponent - variable is used in outer query as arg in non-root r
       }
 
       type B {
-        a(aone: Int): A
+        a(aone: Int, atwo: Int): A
         bField: String
       }
 
@@ -2121,10 +2123,7 @@ Test(`delegateToComponent - variable is used in outer query as arg in non-root r
         async a(root, args, context, info) {
           const a = await GraphQLComponent.delegateToComponent(primitive, {
             contextValue: context,
-            info,
-            args: {
-              atwo: 'hello'
-            }
+            info
           });
           return a;
         }
@@ -2136,7 +2135,7 @@ Test(`delegateToComponent - variable is used in outer query as arg in non-root r
   const document = gql`
     query something($first: Int, $second: C, $third: Boolean) {
       b(bone: $first, btwo: $second) {
-        a(aone: $first) {
+        a(aone: $first, atwo: $first) {
           aField
         }
         bField
@@ -2154,10 +2153,84 @@ Test(`delegateToComponent - variable is used in outer query as arg in non-root r
       third: true
     }
   });
-
-  console.log(graphql.printSchema(composite.schema));
   
   t.notOk(result.errors, 'no errors');
   t.deepEqual(result.data.b, { a: { aField: 'aField'}, bField: 'bField' }, 'result resolved as expected');
+  t.end();
+});
+
+Test('delegateToComponent - delegated selection set contains fields that are not in schema being delegated to (pruning case)', async (t) => {
+  const primitive = new GraphQLComponent({
+    types: `
+      type Query {
+        a(foo: String): A
+      }
+
+      type A {
+        aField1: String
+      }
+
+      type B {
+        bField: String
+      }
+    `,
+    resolvers: {
+      Query: {
+        a(_root, _args, _context, info) {
+          t.equal(info.fieldNodes[0].selectionSet.selections.length, 1, 'only 1 field in the selection set');
+          t.equal(info.fieldNodes[0].selectionSet.selections[0].name.value, 'aField1', 'expected only aField1 in selection set');
+          return { aField1: 'aField1'}
+        }
+      }
+    }
+  });
+
+  const composite = new GraphQLComponent({
+    types: `
+      type Query {
+        aById(id: ID): A
+      }
+
+      type A {
+        b(bArg: Int!): B
+      }
+    `,
+    resolvers: {
+      Query: {
+        async aById(root, args, context, info) {
+          const a = await GraphQLComponent.delegateToComponent(primitive, {
+            info,
+            contextValue: context,
+            targetRootField: 'a'
+          })
+          return { ...a, b: { bField: 'bField' }};
+        }
+      }
+    },
+    imports: [primitive]
+  });
+
+  const document = gql`
+    query aQuery($id: ID, $barg: Int!) {
+      aById(id: $id) {
+        aField1
+        b(bArg: $barg) {
+          bField
+        }
+      }
+    }
+  `;
+
+  const result = await graphql.execute({
+    document,
+    schema: composite.schema,
+    contextValue: {},
+    variableValues: {
+      id: 1,
+      barg: 2
+    }
+  });
+  t.notOk(result.errors, 'no errors');
+  t.deepEquals(result.data, { aById: { aField1: 'aField1', b: { bField: 'bField'}}}, 'result resolved as expected');
   t.end();
 });

--- a/lib/delegate/index.js
+++ b/lib/delegate/index.js
@@ -4,7 +4,6 @@ const {
   execute,
   subscribe,
   isAbstractType,
-  isInputType,
   getNamedType,
   print,
   astFromValue,
@@ -12,7 +11,6 @@ const {
   TypeInfo,
   visit,
   visitWithTypeInfo,
-  typeFromAST
 } = require('graphql');
 const set = require('lodash.set');
 const get = require('lodash.get');
@@ -138,57 +136,82 @@ const createSubOperationDocument = function (component, targetRootField, args, s
     selectionSet: { kind: Kind.SELECTION_SET, selections }
   };
 
-  // only keep variable definitions that are input types or are a type
-  // found in the target schema
-  const variableDefinitions = info.operation.variableDefinitions.filter((variableDefinitionNode) => {
-    const {type: typeNode} = variableDefinitionNode;
-    return isInputType(typeNode) || !!typeFromAST(component.schema, typeNode);
-  });
-
   const operationDefinition = {
     kind: Kind.OPERATION_DEFINITION,
     operation: info.operation.operation,
-    selectionSet: { kind: Kind.SELECTION_SET, selections: [targetRootFieldNode]},
-    variableDefinitions
+    selectionSet: { kind: Kind.SELECTION_SET, selections: [targetRootFieldNode]}
   };
 
   const definitions = [operationDefinition];
+
   for (const [, fragmentDefinition] of Object.entries(info.fragments)) {
     definitions.push(fragmentDefinition);
   }
 
   const document = { kind: Kind.DOCUMENT, definitions };
-  const schemaConfig = component.schema.toConfig();
-  // only perform the below traversal if the delegatee's schema has an
-  // abstract type that is implemented
-  if (schemaConfig.types.some((type) => isAbstractType(type))) {
-    const typeInfo = new TypeInfo(component.schema);
-    // traverse the document's selection sets and add __typename to the
-    // selection set for any field that is an abstract type
-    return visit(document, visitWithTypeInfo(typeInfo, {
-      [Kind.SELECTION_SET](node) {
-        const parentType = typeInfo.getParentType();
-        let nodeSelections = node.selections;
-        if (parentType && isAbstractType(parentType)) {
-          nodeSelections = nodeSelections.concat({
-            kind: Kind.FIELD,
-            name: {
-              kind: Kind.NAME,
-              value: '__typename'
-            }
-          });
-        }
 
-        if (nodeSelections !== node.selections) {
-          return {
-            ...node,
-            selections: nodeSelections
+  const schemaConfig = component.schema.toConfig();
+  const typeInfo = new TypeInfo(component.schema);
+  const visitFunctions = {};
+  // if the schema we are delegating to has abstract types
+  // add a visitor function that traverses the selection sets
+  // and adds __typename to the selection set for return types
+  // that are abstract
+  if (schemaConfig.types.some((type) => isAbstractType(type))) {
+    visitFunctions[Kind.SELECTION_SET] = function (node) {
+      const parentType = typeInfo.getParentType();
+      let nodeSelections = node.selections;
+      if (parentType && isAbstractType(parentType)) {
+        nodeSelections = nodeSelections.concat({
+          kind: Kind.FIELD,
+          name: {
+            kind: Kind.NAME,
+            value: '__typename'
           }
+        });
+      }
+
+      if (nodeSelections !== node.selections) {
+        return {
+          ...node,
+          selections: nodeSelections
         }
       }
-    }));
+    }
   }
-  return document;
+
+  
+  // prune fields in the delegated selection set that are not defined
+  // in the schema we are delegating to
+  visitFunctions[Kind.FIELD] = function () {
+    const fieldDef = typeInfo.getFieldDef();
+    // if the field isn't defined in delegated schema, return null to remove the field from the delegated document
+    if (!fieldDef) {
+      return null;
+    }
+  }
+
+  // if the outer operation has variable definitions, determine
+  // which ones are used in the delegated document and prune out
+  // any variable definitions that aren't used
+  const variableDefinitions = new Set();
+  if (info.operation.variableDefinitions.length > 0) {
+    visitFunctions[Kind.VARIABLE] = function (node) {
+      const matchingVarDef = info.operation.variableDefinitions.find((varDef) => varDef.variable.name.value === node.name.value);
+      if (matchingVarDef) {
+        variableDefinitions.add(matchingVarDef);
+      }
+    }
+  }
+
+  // modify the above constructed document via visit() functions
+  const modifiedDelegateDocument = visit(document, visitWithTypeInfo(typeInfo, visitFunctions));
+
+  // TODO: there may be a more elegant way to add the variable definitions to
+  // the document, but we do know that the operation definition is the first
+  // definition in the definitions array due to the above construction
+  modifiedDelegateDocument.definitions[0].variableDefinitions = Array.from(variableDefinitions);
+  return modifiedDelegateDocument;
 }
 
 /**


### PR DESCRIPTION
All in all - we should have this feature for delegateToComponent - it automatically prunes out unnecessary selections in the delegated document which will reduce error situations and fully address the variable forwarding edge cases

I expect to release this as a minor version bump, since it is technically a feature added to `delegateToComponent`