### PR TITLE
fix delegate selection set pruning to use parent types/parent type fi…

### DIFF
--- a/lib/delegate/__tests__.js
+++ b/lib/delegate/__tests__.js
@@ -2245,7 +2245,7 @@ Test(`delegateToComponent - variables are present in delegated selection set`, a
   t.end();
 });
 
-Test('delegateToComponent - delegated selection set contains fields that are not in schema being delegated to (pruning case)', async (t) => {
+Test('delegateToComponent - delegated selection set from root resolver contains fields that are not in schema being delegated to (pruning)', async (t) => {
   const primitive = new GraphQLComponent({
     types: `
       type Query {
@@ -2318,5 +2318,82 @@ Test('delegateToComponent - delegated selection set contains fields that are not
   });
   t.notOk(result.errors, 'no errors');
   t.deepEquals(result.data, { aById: { aField1: 'aField1', b: { bField: 'bField'}}}, 'result resolved as expected');
+  t.end();
+});
+
+Test('delegateToComponent - delegated selection set from non-root resolver contains fields that are not in schema being delegated to (pruning)', async (t) => {
+  const primitive = new GraphQLComponent({
+    types: `
+      type Query {
+        a: A
+      }
+
+      type A {
+        aField1: String
+      }
+    `,
+    resolvers: {
+      Query: {
+        a(_root, _args, _context, info) {
+          t.equal(info.fieldNodes[0].selectionSet.selections.length, 1, 'only 1 field in the selection set');
+          t.equal(info.fieldNodes[0].selectionSet.selections[0].name.value, 'aField1', 'expected only aField1 in selection set');
+          return { aField1: 'aField1'};
+        }
+      }
+    }
+  });
+
+  const composite = new GraphQLComponent({
+    types: `
+      type Query {
+        b: B
+      }
+
+      type B {
+        a: APrime
+      }
+
+      type APrime {
+        aField1: String
+        aPrimeField1: String
+      }
+    `,
+    resolvers: {
+      Query: {
+        async b() {
+          return {};
+        }
+      },
+      B: {
+        async a(_root, _args, context, info) {
+          const a = await GraphQLComponent.delegateToComponent(primitive, {
+            contextValue: context,
+            info
+          });
+          return {...a, aPrimeField1: 'aPrimeField1'};
+        }
+      }
+    },
+    imports: [primitive]
+  });
+
+  const document = gql`
+    query {
+      b {
+        a {
+          aField1
+          aPrimeField1
+        }
+      }
+    }
+  `;
+
+  const result = await graphql.execute({
+    document,
+    schema: composite.schema,
+    contextValue: {}
+  });
+  t.notOk(result.errors, 'no errors');
+  t.deepEquals(result.data, { b: { a: { aField1: 'aField1', aPrimeField1: 'aPrimeField1'}}}, 'result resolved as expected');
   t.end();
 });

--- a/lib/delegate/index.js
+++ b/lib/delegate/index.js
@@ -1,14 +1,16 @@
 
-const { 
+const {
   Kind,
   execute,
   subscribe,
   isAbstractType,
+  isObjectType,
   getNamedType,
   print,
   astFromValue,
   coerceInputValue,
   TypeInfo,
+  TypeNameMetaFieldDef,
   visit,
   visitWithTypeInfo,
 } = require('graphql');
@@ -18,7 +20,7 @@ const debug = require('debug')('graphql-component:delegate');
 
 /**
  * extracts the Array<SelectionNode> at the given path
- * @param {String} path - dot seperated string defining the path to the sub 
+ * @param {String} path - dot seperated string defining the path to the sub
  * selection
  * @param {Array<SelectionNode>} selections - an array of SelectionNode objects
  * @returns {Array<SelectionNode>} - an array of SelectionNode objects
@@ -66,10 +68,10 @@ const createSubOperationDocument = function (component, targetRootField, args, s
   let targetRootTypeFields;
   if (info.operation.operation === 'query') {
     targetRootTypeFields = component.schema.getQueryType().getFields();
-  } 
+  }
   else if (info.operation.operation === 'mutation') {
     targetRootTypeFields = component.schema.getMutationType().getFields();
-  } 
+  }
   else if (info.operation.operation === 'subscription') {
     targetRootTypeFields = component.schema.getSubscriptionType().getFields();
   }
@@ -104,7 +106,7 @@ const createSubOperationDocument = function (component, targetRootField, args, s
       if (args[definedArg.name]) {
         const definedArgNamedType = getNamedType(definedArg.type);
         // this provides us some type safety by trying to coerce the user's
-        // argument value to the type defined by the target field's matching 
+        // argument value to the type defined by the target field's matching
         // argument - if they dont match, it will throw a meaningful error.
         // without this astFromValue would coerce things we dont want coerced
         const coercedArgValue = coerceInputValue(args[definedArg.name], definedArgNamedType);
@@ -148,16 +150,17 @@ const createSubOperationDocument = function (component, targetRootField, args, s
     definitions.push(fragmentDefinition);
   }
 
+  // assemble the document object which includes the operation definition
+  // and fragment definitions (if present)
   const document = { kind: Kind.DOCUMENT, definitions };
 
-  const schemaConfig = component.schema.toConfig();
   const typeInfo = new TypeInfo(component.schema);
   const visitFunctions = {};
   // if the schema we are delegating to has abstract types
   // add a visitor function that traverses the selection sets
   // and adds __typename to the selection set for return types
   // that are abstract
-  if (schemaConfig.types.some((type) => isAbstractType(type))) {
+  if (component.schema.toConfig().types.some((type) => isAbstractType(type))) {
     visitFunctions[Kind.SELECTION_SET] = function (node) {
       const parentType = typeInfo.getParentType();
       let nodeSelections = node.selections;
@@ -180,14 +183,16 @@ const createSubOperationDocument = function (component, targetRootField, args, s
     }
   }
 
-  
-  // prune fields in the delegated selection set that are not defined
-  // in the schema we are delegating to
-  visitFunctions[Kind.FIELD] = function () {
-    const fieldDef = typeInfo.getFieldDef();
-    // if the field isn't defined in delegated schema, return null to remove the field from the delegated document
-    if (!fieldDef) {
-      return null;
+  // prune selection set fields that are not defined in the target schema
+  visitFunctions[Kind.FIELD] = function (node) {
+    const parentType = typeInfo.getParentType();
+    if (isObjectType(parentType) || isAbstractType(parentType)) {
+      const parentTypeFields = parentType.getFields();
+      const field = node.name.value === '__typename' ? TypeNameMetaFieldDef : parentTypeFields[node.name.value];
+
+      if (!field) {
+        return null;
+      }
     }
   }
 
@@ -216,11 +221,11 @@ const createSubOperationDocument = function (component, targetRootField, args, s
 
 /**
  * merges errors in the input errors array into data based on the error path
- * @param {object} data - the data portion of a graphql result 
+ * @param {object} data - the data portion of a graphql result
  * @param {Array<object>} errors - the errors portions of a graphql result
  * @param {GraphQLResolveInfo} info - the info object from the resolver who
  * called delegateToComponent
- * @returns - nothing - modifies data parameter by reference 
+ * @returns - nothing - modifies data parameter by reference
  */
 const mergeErrors = function (data, errors, info) {
   // use info to build the path tha was traversed prior to the delegateToComponent call
@@ -232,7 +237,7 @@ const mergeErrors = function (data, errors, info) {
   }
 
   for (let error of errors) {
-    
+
     const { path } = error;
     // errors can occur via graphql.execute() that occur before
     // actual execution occurs with which the error won't have a path
@@ -270,22 +275,22 @@ const mergeErrors = function (data, errors, info) {
 /**
  * executes (delegates) a graphql operation on the input component's schema
  * @param {GraphQLComponent} component - the component to delegate execution to
- * @param {object} options - an options object to customize the delegated 
+ * @param {object} options - an options object to customize the delegated
  * operation
  * @param {GraphQLResolveInfo} options.info - the info object from the calling resolver
- * @param {object} options.contextValue - the context object from the calling 
+ * @param {object} options.contextValue - the context object from the calling
  * resolver
- * @param {string} [options.targetRootField] - the name of the root type field 
- * the delegated operation will execute. Defaults to the field name of the 
+ * @param {string} [options.targetRootField] - the name of the root type field
+ * the delegated operation will execute. Defaults to the field name of the
  * calling resolver
- * @param {string} [options.subPath] - a dot separated string to limit the 
+ * @param {string} [options.subPath] - a dot separated string to limit the
  * delegated selection set to a given path in the calling resolver's return type
- * @param {object} [options.args] - an object literal whose keys/values are 
+ * @param {object} [options.args] - an object literal whose keys/values are
  * passed as args to the delegatee's target field resolver.
  * @returns the result of the delegated operation to the targetRootField with
  * any errors merged into the result at their given path
  */
-const delegateToComponent = async function (component, options) { 
+const delegateToComponent = async function (component, options) {
   let {
     subPath,
     contextValue,
@@ -311,12 +316,12 @@ const delegateToComponent = async function (component, options) {
 
 
   debug(`delegating ${print(document)} to ${component.name}`);
-  
+
   if (info.operation.operation === 'query' || info.operation.operation === 'mutation') {
     let { data, errors = []} = await execute({
-      document, 
-      schema: component.schema, 
-      rootValue: info.rootValue, 
+      document,
+      schema: component.schema,
+      rootValue: info.rootValue,
       contextValue,
       variableValues: info.variableValues
     });
@@ -324,7 +329,7 @@ const delegateToComponent = async function (component, options) {
     if (!data) {
       data = {};
     }
-    
+
     if (errors.length > 0) {
       mergeErrors(data, errors, info);
     }


### PR DESCRIPTION
…elds rather than getFieldDef()

Through some testing - I found that getFieldDef() was not the correct method to use to determine if a field in a delegated selection set is present/can be resolved by the schema being delegated to. 