### PR TITLE
tweak/fix non-root resolver wrapping

### DIFF
--- a/lib/delegate/__tests__.js
+++ b/lib/delegate/__tests__.js
@@ -55,7 +55,7 @@ Test('contextValue not passed to delegateToComponent', async (t) => {
   });
 
   const document = gql`
-    query { 
+    query {
       a {
         aField
         addedField
@@ -126,14 +126,14 @@ Test('info not passed to delegateToComponent', async (t) => {
   });
 
   const document = gql`
-    query { 
+    query {
       a {
         aField
         addedField
       }
     }
   `;
-  
+
   const result = await graphql.execute({
     document,
     schema: composite.schema,
@@ -198,12 +198,12 @@ Test('composite component delegates from root type resolver to primitive compone
   });
 
   const document = gql`
-    query { 
+    query {
       composite1: a {
         aField
         addedField
       }
-        
+
       composite2: a {
         anotherAField
         addedField
@@ -219,7 +219,7 @@ Test('composite component delegates from root type resolver to primitive compone
   });
 
   t.ok(!result.errors, 'no errors');
-  
+
   const { composite1, composite2 } = result.data;
 
   t.deepEqual(composite1, { aField: 'a field', addedField: 'added field' }, 'received correct first result');
@@ -281,12 +281,12 @@ Test('composite delegates from root type resolver to primitive component field w
   });
 
   const document = gql`
-    query { 
+    query {
       composite1: b {
         aField
         addedField
       }
-        
+
       composite2: b {
         anotherAField
         addedField
@@ -302,7 +302,7 @@ Test('composite delegates from root type resolver to primitive component field w
   });
 
   t.ok(!result.errors, 'no errors');
-  
+
   const { composite1, composite2 } = result.data;
 
   t.deepEqual(composite1, { aField: 'a field', addedField: 'added field' }, 'received correct first result');
@@ -375,15 +375,15 @@ Test('composite component delegates from root type resolver to primitive compone
   });
 
   const document = gql`
-    query { 
+    query {
       composite1: b {
         bField
-        a { 
+        a {
           aField
           anotherAField
         }
       }
-        
+
       composite2: b {
         bField
         a {
@@ -402,7 +402,7 @@ Test('composite component delegates from root type resolver to primitive compone
   });
 
   t.notOk(result.errors, 'no errors');
-  
+
   const { composite1, composite2 } = result.data;
 
   t.deepEqual(composite1, { bField: 'b field', a: { aField: 'a field', anotherAField: 'another a field' }}, 'received correct first result');
@@ -471,7 +471,7 @@ Test('composite component delegates from non-root type resolver to primitive com
   });
 
   const document = gql`
-    query { 
+    query {
       composite1: b {
         a {
           aField
@@ -494,7 +494,7 @@ Test('composite component delegates from non-root type resolver to primitive com
   });
 
   t.ok(!result.errors, 'no errors');
-  
+
   const { composite1, composite2 } = result.data;
 
   t.deepEqual(composite1, { a: { aField: 'a field', addedField: 'added field', }}, 'received correct first result');
@@ -564,7 +564,7 @@ Test('composite component delegates from non-root type resolver to primitive com
   });
 
   const document = gql`
-    query { 
+    query {
       composite1: b {
         bField {
           aField
@@ -587,7 +587,7 @@ Test('composite component delegates from non-root type resolver to primitive com
   });
 
   t.ok(!result.errors, 'no errors');
-  
+
   const { composite1, composite2 } = result.data;
 
   t.deepEqual(composite1, { bField: { aField: 'a field', addedField: 'added field', }}, 'received correct first result');
@@ -693,6 +693,7 @@ Test('composite component delegates from non-root type resolver to primitive com
 
 Test('delegateToComponent - nested abstract type is resolved without error', async (t) => {
   let resolveTypeCount = 0;
+  let materialNonRootResolverCount = 0;
   const primitive = new GraphQLComponent({
     types: `
       type Query {
@@ -735,7 +736,6 @@ Test('delegateToComponent - nested abstract type is resolved without error', asy
               {
                 node: {
                   id: 2,
-                  material: 'ceramic'
                 }
               }
             ]
@@ -746,11 +746,15 @@ Test('delegateToComponent - nested abstract type is resolved without error', asy
         __resolveType(result) {
           resolveTypeCount += 1;
           if (result.title) {
-            return 'Book'
+            return 'Book';
           }
-          else if (result.material) {
-            return 'Mug'
-          }
+          return 'Mug';
+        }
+      },
+      Mug: {
+        material() {
+          materialNonRootResolverCount += 1;
+          return 'ceramic';
         }
       }
     }
@@ -829,6 +833,7 @@ Test('delegateToComponent - nested abstract type is resolved without error', asy
   }
   t.deepEquals(data, expectedResult, 'data is resolved as expected');
   t.equals(resolveTypeCount, 2, '__resolveType called once per item as expected');
+  t.equals(materialNonRootResolverCount, 1, 'Mug non-root resolver is only executed 1 time as expected');
   t.notOk(errors, 'no errors');
   t.end();
 })
@@ -838,7 +843,7 @@ Test('delegateToComponent - nested abstract type is resolved without error', asy
 /*
  * case 1: target field has no arguments and calling resolver has no arguments
  * result: no arguments are forwarded even if caller of delegateToComponent
- * provides them  
+ * provides them
 */
 Test('delegateToComponent - case 1 - no args provided to delegateToComponent', async (t) => {
   const reviews = new GraphQLComponent({
@@ -981,7 +986,7 @@ Test('delegateToComponent - case 1 - args provided to delegateToComponent', asyn
 
 /*
  * case 2: target field has no arguments and calling resolver has arguments
- * result: no arguments are forwarded from calling resolver or from the caller  
+ * result: no arguments are forwarded from calling resolver or from the caller
  * of delegateToComponent if provided
 */
 Test('delegateToComponent - case 2 - no args provided to delegateToComponent', async (t) => {
@@ -1127,8 +1132,8 @@ Test('delegateToComponent - case 2 - args provided to delegateToComponent', asyn
 
 /*
 * case 3: target field has arguments and calling resolver has arguments
-* result: matching args to the target field provided by the caller of 
-* delegateToComponent take priority and are forwarded, otherwise falling back 
+* result: matching args to the target field provided by the caller of
+* delegateToComponent take priority and are forwarded, otherwise falling back
 * to matching args from the calling resolver, no other args are forwarded
 */
 
@@ -1524,7 +1529,7 @@ Test('delegateToComponent - user provided args of various types: ID (as Int), ID
             info,
             contextValue: context,
             targetRootField: 'reviewsByPropertyId',
-            args: { 
+            args: {
               intID: 2,
               stringID: '9',
               bool: true,
@@ -2016,7 +2021,7 @@ Test('delegateToComponent - with errors - verify error path when delegation occu
 Test(`delegateToComponent - variable in outer query for type that doesn't exist in schema being delegated to`, async (t) => {
   const primitive = new GraphQLComponent({
     types: `
-      type Query { 
+      type Query {
         a(aone: Int, atwo: String): A
       }
 
@@ -2090,7 +2095,7 @@ Test(`delegateToComponent - variable in outer query for type that doesn't exist 
       third: true
     }
   });
-  
+
   t.notOk(result.errors, 'no errors');
   t.deepEqual(result.data.b, { a: { aField: 'aField'}, bField: 'bField' }, 'result resolved as expected');
   t.end();
@@ -2099,7 +2104,7 @@ Test(`delegateToComponent - variable in outer query for type that doesn't exist 
 Test(`delegateToComponent - variables are present in delegated selection set`, async (t) => {
   const primitive = new GraphQLComponent({
     types: `
-      type Query { 
+      type Query {
         a(aone: Int, atwo: String): A
       }
 
@@ -2176,7 +2181,7 @@ Test(`delegateToComponent - variables are present in delegated selection set`, a
       third: true
     }
   });
-  
+
   t.notOk(result.errors, 'no errors');
   t.deepEqual(result.data.b, { a: { aField: 'aField'}, bField: 'bField' }, 'result resolved as expected');
   t.end();

--- a/lib/resolvers/index.js
+++ b/lib/resolvers/index.js
@@ -6,14 +6,14 @@ const cloneDeep = require('lodash.clonedeep');
 
 /**
  * memoizes resolver functions such that calls of an identical resolver (args/context/path) within the same request context are avoided
- * @param {string} parentType - the type whose field resolver is being 
+ * @param {string} parentType - the type whose field resolver is being
  * wrapped/memoized
- * @param {string} fieldName -  the field on the parentType whose resolver 
+ * @param {string} fieldName -  the field on the parentType whose resolver
  * function is being wrapped/memoized
  * @param {function} resolve - the resolver function that parentType.
  * fieldName is mapped to
  * @returns {function} a function that wraps the input resolver function and
- * whose closure scope contains a WeakMap to achieve memoization of the wrapped 
+ * whose closure scope contains a WeakMap to achieve memoization of the wrapped
  * input resolver function
  */
 const memoize = function (parentType, fieldName, resolve) {
@@ -51,9 +51,9 @@ const memoize = function (parentType, fieldName, resolve) {
 /**
  * excludes types and/or fields on types from an input resolver map
  * @param {Object} resolvers - the input resolver map to filter
- * @param {Array<string>} excludes - an array of exclusions in the general form 
- * of "type.field". This format supports excluding all types ('*'), an entire 
- * type and the fields it encloses ('type', 'type.', 'type.*'), and individual 
+ * @param {Array<string>} excludes - an array of exclusions in the general form
+ * of "type.field". This format supports excluding all types ('*'), an entire
+ * type and the fields it encloses ('type', 'type.', 'type.*'), and individual
  * fields on a type ('type.somefield').
  * @returns {Object} - a new resolver map with the applied exclusions
  */
@@ -87,9 +87,9 @@ const filterResolvers = function (resolvers, excludes) {
 /**
  * binds an object context to resolver functions in the input resolver map
  * @param {Object} bind - the object context to bind to resolver functions
- * @param {Object} resolvers - the resolver map containing the resolver 
+ * @param {Object} resolvers - the resolver map containing the resolver
  * functions to bind
- * @returns {Object} - an object identical in structure to the input resolver 
+ * @returns {Object} - an object identical in structure to the input resolver
  * map, except with resolver function bound to the input argument bind
  */
 const bindResolvers = function (bind, resolvers = {}) {
@@ -115,7 +115,7 @@ const bindResolvers = function (bind, resolvers = {}) {
         bound[type][field] = memoize(type, field, resolverFunc.bind(bind));
       } else {
         // for types other than Query/Mutation - conditionally bind since in
-        // some cases (Subscriptions and enum remaps) resolverFunc will be 
+        // some cases (Subscriptions and enum remaps) resolverFunc will be
         // an object instead of a function
         bound[type][field] = typeof resolverFunc === 'function' ? resolverFunc.bind(bind) : resolverFunc;
       }
@@ -125,17 +125,18 @@ const bindResolvers = function (bind, resolvers = {}) {
 };
 
 /**
- * wraps non root type resolvers from the input resolver map that quick returns 
+ * wraps non root type resolvers from the input resolver map that quick returns
  * if __typename is detected
- * @param {object} resolvers - the input resolver map with which non root 
+ * @param {object} resolvers - the input resolver map with which non root
  * resolvers will be wrapped
- * @returns {object} the resulting resolver map with non root type resolvers 
+ * @returns {object} the resulting resolver map with non root type resolvers
  * wrapped
  */
 const wrapNonRootTypeResolvers = function (resolvers) {
   const result = {};
 
   for (const [type, fieldResolvers] of Object.entries(resolvers)) {
+    // skip over resolvers on root types
     if (['Query', 'Mutation', 'Subscription'].indexOf(type) === -1) {
       if (!result[type]) {
         result[type] = {};
@@ -145,12 +146,27 @@ const wrapNonRootTypeResolvers = function (resolvers) {
         if (typeof resolver !== 'function') {
           result[type][field] = resolver;
         }
-        else {
-          result[type][field] = function (_, ...args) {
-            if (_.__typename) {
-              return field.startsWith('__') ? _.__typename : _[field];
+        // wrap fields that start with __ (such as __resolveType) and return __typename if it was
+        // already resolved (to prevent double execution in situations where delegateToComponent
+        // results in resolution of an interface type)
+        else if (field.startsWith('__')) {
+          result[type][field] = function (root, ...args) {
+            if (root.__typename) {
+              return root.__typename;
             }
-            return resolver(_, ...args);
+            return resolver(root, ...args);
+          }
+        }
+        // all other non-root type field resolvers are wrapped to also attempt to prevent
+        // double execution in delegateToComponent situations - we simply check if the field
+        // is present in the root result and if so return it instead of running the
+        // actual field resolver
+        else {
+          result[type][field] = function (root, ...args) {
+            if (root[field]) {
+              return root[field];
+            }
+            return resolver(root, ...args);
           }
         }
       }
@@ -164,10 +180,10 @@ const wrapNonRootTypeResolvers = function (resolvers) {
 }
 
 /**
- * returns a resolver map representing imported resolvers from the input 
+ * returns a resolver map representing imported resolvers from the input
  * component
  * @param {GraphQLComponent} component - the component to import resolvers from
- * @param {Array<Array<string>>} excludes - resolvers to exclude from the input 
+ * @param {Array<Array<string>>} excludes - resolvers to exclude from the input
  * component
  * @return {Object} - imported resolvers
  */


### PR DESCRIPTION
Jeremy Paden brought up an issue regarding component usage in a federated setup. They are upgrading from graphql-component v1 to v2 and were suddenly getting null back for a field in their federated setup. We traced it down to this non-root resolver wrapping which is in place to prevent double execution of non-root resolvers in delegate situations.

The problem was in the federated setup, __typename is used heavily to resolve types between federated graphql apis. Therefore, the resolver wrapping in this case detected __typename in a resolver that wasn't __resolveType and therefore tried to return the result from the parent resolver which was null. 

I therefore, split out the resolver wrapping to be more explicit:
* wrap __resolveType (or __isTypeOf()) explicitly and only look for __typename in the parent for those resolvers to prevent double execution of __resolveType (or __isTypeOf())
* wrap all other non-root type field resolvers and simply look for the field in the parent, if so return it, otherwise execute the actual non-root type field resolver

This ensure we are calling through at the appropriate time while also preventing double execution in delegateToComponent situations as the passing tests prove. Hope that makes sense :) 