### PR TITLE
Fixes #87 - undo field resolver wrapping

### DIFF
--- a/lib/delegate/__tests__.js
+++ b/lib/delegate/__tests__.js
@@ -324,7 +324,7 @@ Test('composite component delegates from root type resolver to primitive compone
     resolvers: {
       Query: {
         a(_root, _args, _context, info) {
-          const selections = info.fieldNodes[0].selectionSet.selections.map((selectionNode) => { return selectionNode.name.value});
+          const selections = info.fieldNodes[0].selectionSet.selections.map((selectionNode) => { return selectionNode.name.value });
           t.equals(selections.indexOf('bField'), -1, 'parent field not in sub path not included in child selection set');
           return {
             aField: 'a field',
@@ -405,8 +405,8 @@ Test('composite component delegates from root type resolver to primitive compone
 
   const { composite1, composite2 } = result.data;
 
-  t.deepEqual(composite1, { bField: 'b field', a: { aField: 'a field', anotherAField: 'another a field' }}, 'received correct first result');
-  t.deepEqual(composite2, { bField: 'b field', a: { anotherAField: 'another a field', addedField: 'added field' }}, 'received correct second result');
+  t.deepEqual(composite1, { bField: 'b field', a: { aField: 'a field', anotherAField: 'another a field' } }, 'received correct first result');
+  t.deepEqual(composite2, { bField: 'b field', a: { anotherAField: 'another a field', addedField: 'added field' } }, 'received correct second result');
   t.end();
 });
 
@@ -497,8 +497,8 @@ Test('composite component delegates from non-root type resolver to primitive com
 
   const { composite1, composite2 } = result.data;
 
-  t.deepEqual(composite1, { a: { aField: 'a field', addedField: 'added field', }}, 'received correct first result');
-  t.deepEqual(composite2, { a: { anotherAField: 'another a field', addedField: 'added field' }}, 'received correct second result');
+  t.deepEqual(composite1, { a: { aField: 'a field', addedField: 'added field', } }, 'received correct first result');
+  t.deepEqual(composite2, { a: { anotherAField: 'another a field', addedField: 'added field' } }, 'received correct second result');
   t.end();
 });
 
@@ -590,8 +590,8 @@ Test('composite component delegates from non-root type resolver to primitive com
 
   const { composite1, composite2 } = result.data;
 
-  t.deepEqual(composite1, { bField: { aField: 'a field', addedField: 'added field', }}, 'received correct first result');
-  t.deepEqual(composite2, { bField: { anotherAField: 'another a field', addedField: 'added field' }}, 'received correct second result');
+  t.deepEqual(composite1, { bField: { aField: 'a field', addedField: 'added field', } }, 'received correct first result');
+  t.deepEqual(composite2, { bField: { anotherAField: 'another a field', addedField: 'added field' } }, 'received correct second result');
   t.end();
 });
 
@@ -609,7 +609,7 @@ Test('composite component delegates from non-root type resolver to primitive com
     resolvers: {
       Query: {
         a(_root, _args, _context, info) {
-          const selections = info.fieldNodes[0].selectionSet.selections.map((selectionNode) => { return selectionNode.name.value});
+          const selections = info.fieldNodes[0].selectionSet.selections.map((selectionNode) => { return selectionNode.name.value });
           t.equals(selections.indexOf('compositeBField'), -1, 'parent field not in sub path not included in child selection set');
           return {
             aField: 'a field',
@@ -638,7 +638,7 @@ Test('composite component delegates from non-root type resolver to primitive com
     `,
     resolvers: {
       Query: {
-        b: async function (){
+        b: async function () {
           return {}
         }
       },
@@ -687,7 +687,7 @@ Test('composite component delegates from non-root type resolver to primitive com
   });
 
   t.notOk(result.errors, 'no errors');
-  t.deepEqual(result.data, { b: { compositeB: { compositeBField: 'composite b field', a: { aField: 'a field', anotherAField: 'another a field', addedField: 'added field'}}}}, 'complex delegation result resolved successfully');
+  t.deepEqual(result.data, { b: { compositeB: { compositeBField: 'composite b field', a: { aField: 'a field', anotherAField: 'another a field', addedField: 'added field' } } } }, 'complex delegation result resolved successfully');
   t.end();
 });
 
@@ -779,7 +779,7 @@ Test('delegateToComponent - nested abstract type is resolved without error', asy
             contextValue: context,
             subPath: 'things'
           });
-          return {things: result};
+          return { things: result };
         }
       }
     },
@@ -833,7 +833,8 @@ Test('delegateToComponent - nested abstract type is resolved without error', asy
   }
   t.deepEquals(data, expectedResult, 'data is resolved as expected');
   t.equals(resolveTypeCount, 2, '__resolveType called once per item as expected');
-  t.equals(materialNonRootResolverCount, 1, 'Mug non-root resolver is only executed 1 time as expected');
+  // Turn this check back on when the double execution protection is brought back. Off because of Issue #87.
+  // t.equals(materialNonRootResolverCount, 1, 'Mug non-root resolver is only executed 1 time as expected');
   t.notOk(errors, 'no errors');
   t.end();
 })
@@ -861,7 +862,7 @@ Test('delegateToComponent - case 1 - no args provided to delegateToComponent', a
       Query: {
         reviews(_root, args) {
           t.equals(Object.keys(args).length, 0, 'no args forwarded to target field');
-          return [{ id: 'revid', content: 'some review content'}];
+          return [{ id: 'revid', content: 'some review content' }];
         }
       }
     }
@@ -909,7 +910,7 @@ Test('delegateToComponent - case 1 - no args provided to delegateToComponent', a
     schema: property.schema,
     contextValue: {}
   });
-  t.deepEqual(result.data, { property: { id: '1', reviews: [{ id: 'revid', content: 'some review content'}]}}, 'propery reviews successfully resolved');
+  t.deepEqual(result.data, { property: { id: '1', reviews: [{ id: 'revid', content: 'some review content' }] } }, 'propery reviews successfully resolved');
   t.end();
 });
 
@@ -929,7 +930,7 @@ Test('delegateToComponent - case 1 - args provided to delegateToComponent', asyn
       Query: {
         reviews(_root, args) {
           t.equals(Object.keys(args).length, 0, 'no args forwarded to target field');
-          return [{ id: 'revid', content: 'some review content'}];
+          return [{ id: 'revid', content: 'some review content' }];
         }
       }
     }
@@ -980,7 +981,7 @@ Test('delegateToComponent - case 1 - args provided to delegateToComponent', asyn
     schema: property.schema,
     contextValue: {}
   });
-  t.deepEqual(result.data, { property: { id: '1', reviews: [{ id: 'revid', content: 'some review content'}]}}, 'propery reviews successfully resolved');
+  t.deepEqual(result.data, { property: { id: '1', reviews: [{ id: 'revid', content: 'some review content' }] } }, 'propery reviews successfully resolved');
   t.end();
 })
 
@@ -1005,7 +1006,7 @@ Test('delegateToComponent - case 2 - no args provided to delegateToComponent', a
       Query: {
         reviews(_root, args) {
           t.equals(Object.keys(args).length, 0, 'no args forwarded to target field');
-          return [{ id: 'revid', content: 'some review content'}];
+          return [{ id: 'revid', content: 'some review content' }];
         }
       }
     }
@@ -1054,7 +1055,7 @@ Test('delegateToComponent - case 2 - no args provided to delegateToComponent', a
     schema: property.schema,
     contextValue: {}
   });
-  t.deepEqual(result.data, { propertyById: { id: '1', reviews: [{ id: 'revid', content: 'some review content'}]}}, 'propery reviews successfully resolved');
+  t.deepEqual(result.data, { propertyById: { id: '1', reviews: [{ id: 'revid', content: 'some review content' }] } }, 'propery reviews successfully resolved');
   t.end();
 });
 
@@ -1074,7 +1075,7 @@ Test('delegateToComponent - case 2 - args provided to delegateToComponent', asyn
       Query: {
         reviews(_root, args) {
           t.equals(Object.keys(args).length, 0, 'no args forwarded to target field');
-          return [{ id: 'revid', content: 'some review content'}];
+          return [{ id: 'revid', content: 'some review content' }];
         }
       }
     }
@@ -1126,7 +1127,7 @@ Test('delegateToComponent - case 2 - args provided to delegateToComponent', asyn
     schema: property.schema,
     contextValue: {}
   });
-  t.deepEqual(result.data, { propertyById: { id: '1', reviews: [{ id: 'revid', content: 'some review content'}]}}, 'propery reviews successfully resolved');
+  t.deepEqual(result.data, { propertyById: { id: '1', reviews: [{ id: 'revid', content: 'some review content' }] } }, 'propery reviews successfully resolved');
   t.end();
 });
 
@@ -1155,7 +1156,7 @@ Test('delegateToComponent - case 3 - calling resolver has matching args/extra ar
           t.equals(Object.keys(args).length, 1, '1 arg forwarded to target field');
           t.ok(args.id, 'id arg from calling resolver forwarded');
           t.notOk(args.cached, 'cached arg from calling resolver is not forwarded');
-          return [{ id: 'revid', content: 'some review content'}];
+          return [{ id: 'revid', content: 'some review content' }];
         }
       }
     }
@@ -1205,7 +1206,7 @@ Test('delegateToComponent - case 3 - calling resolver has matching args/extra ar
     schema: property.schema,
     contextValue: {}
   });
-  t.deepEqual(result.data, { propertyById: { id: '1', reviews: [{ id: 'revid', content: 'some review content'}]}}, 'propery reviews successfully resolved');
+  t.deepEqual(result.data, { propertyById: { id: '1', reviews: [{ id: 'revid', content: 'some review content' }] } }, 'propery reviews successfully resolved');
   t.end();
 });
 
@@ -1230,7 +1231,7 @@ Test('delegateToComponent - case 3 - calling resolver has matching args/extra ar
           t.equals(args.foo, 'foo', 'args.foo provided by delegateToComponent caller is passed with expected value');
           t.equals(args.bar, 'bar', 'args.bar provided by delegateToComponent caller is passed with expected value');
           t.notOk(args.cached, 'args.cached from calling resolver is not forwarded');
-          return [{ id: 'revid', content: 'some review content'}];
+          return [{ id: 'revid', content: 'some review content' }];
         }
       }
     }
@@ -1284,7 +1285,7 @@ Test('delegateToComponent - case 3 - calling resolver has matching args/extra ar
     schema: property.schema,
     contextValue: {}
   });
-  t.deepEqual(result.data, { propertyById: { id: '1', reviews: [{ id: 'revid', content: 'some review content'}]}}, 'propery reviews successfully resolved');
+  t.deepEqual(result.data, { propertyById: { id: '1', reviews: [{ id: 'revid', content: 'some review content' }] } }, 'propery reviews successfully resolved');
   t.end();
 });
 
@@ -1305,7 +1306,7 @@ Test('delegateToComponent - case 3 - calling resolver has a matching arg/no extr
         reviewsByPropertyId(_root, args) {
           t.equals(Object.keys(args).length, 1, '1 arg forwarded to target field');
           t.equals(args.id, '2', 'id arg from calling resolver forwarded and has overridden value');
-          return [{ id: 'revid', content: 'some review content'}];
+          return [{ id: 'revid', content: 'some review content' }];
         }
       }
     }
@@ -1357,7 +1358,7 @@ Test('delegateToComponent - case 3 - calling resolver has a matching arg/no extr
     schema: property.schema,
     contextValue: {}
   });
-  t.deepEqual(result.data, { propertyById: { id: '1', reviews: [{ id: 'revid', content: 'some review content'}]}}, 'propery reviews successfully resolved');
+  t.deepEqual(result.data, { propertyById: { id: '1', reviews: [{ id: 'revid', content: 'some review content' }] } }, 'propery reviews successfully resolved');
   t.end();
 });
 
@@ -1385,7 +1386,7 @@ Test('delegateToComponent - case 4 - delegateToComponent caller provides all arg
           t.equals(Object.keys(args).length, 2, '2 args forwarded to target field');
           t.equals(args.id, '2', 'id arg forwarded and has value passed to delegateToComponent');
           t.equals(args.foo, 'foo', 'foo arg forwarded and has value passed to delegateToComponent');
-          return [{ id: 'revid', content: 'some review content'}];
+          return [{ id: 'revid', content: 'some review content' }];
         }
       }
     }
@@ -1438,7 +1439,7 @@ Test('delegateToComponent - case 4 - delegateToComponent caller provides all arg
     schema: property.schema,
     contextValue: {}
   });
-  t.deepEqual(result.data, { property: { id: '1', reviews: [{ id: 'revid', content: 'some review content'}]}}, 'propery reviews successfully resolved');
+  t.deepEqual(result.data, { property: { id: '1', reviews: [{ id: 'revid', content: 'some review content' }] } }, 'propery reviews successfully resolved');
   t.end();
 });
 
@@ -1500,7 +1501,7 @@ Test('delegateToComponent - user provided args of various types: ID (as Int), ID
           t.deepEqual(args.arrayOfString, ['hello', 'goodbye'], 'arrayOfString arg from delegateToComponent coerced and passed through as expected');
           t.deepEqual(args.arrayOfEnum, ['COMPLETE', 'PENDING'], 'arrayOfEnum arg from delegateToComponent coerced and passed through as expected');
           t.deepEqual(args.arrayOfObj, [{ from: 'from-date-1', to: 'to-date-1' }, { from: 'from-date-2', to: 'to-date-2' }], 'arrayOfObj arg from delegateToComponent coerced and passed through as expected');
-          return [{ id: 'revid', content: 'some review content'}];
+          return [{ id: 'revid', content: 'some review content' }];
         }
       }
     }
@@ -1544,7 +1545,7 @@ Test('delegateToComponent - user provided args of various types: ID (as Int), ID
               arrayOfFloat: [7.0, 8.0],
               arrayOfString: ['hello', 'goodbye'],
               arrayOfEnum: ['COMPLETE', 'PENDING'],
-              arrayOfObj: [{ from: 'from-date-1', to: 'to-date-1'}, {from: 'from-date-2', to: 'to-date-2'}]
+              arrayOfObj: [{ from: 'from-date-1', to: 'to-date-1' }, { from: 'from-date-2', to: 'to-date-2' }]
             }
           });
           return reviews;
@@ -1569,7 +1570,7 @@ Test('delegateToComponent - user provided args of various types: ID (as Int), ID
     schema: property.schema,
     contextValue: {}
   });
-  t.deepEqual(result.data, { propertyById: { id: '1', reviews: [{ id: 'revid', content: 'some review content'}]}}, 'propery reviews successfully resolved');
+  t.deepEqual(result.data, { propertyById: { id: '1', reviews: [{ id: 'revid', content: 'some review content' }] } }, 'propery reviews successfully resolved');
   t.end();
 });
 
@@ -1588,7 +1589,7 @@ Test('delegateToComponent - user passes wrong type for arg', async (t) => {
     resolvers: {
       Query: {
         reviewsByPropertyId() {
-          return [{ id: 'revid', content: 'some review content'}];
+          return [{ id: 'revid', content: 'some review content' }];
         }
       }
     }
@@ -1663,7 +1664,7 @@ Test('delegateToComponent - target field non-nullable arg is not passed', async 
     resolvers: {
       Query: {
         reviewsByPropertyId() {
-          return [{ id: 'revid', content: 'some review content'}];
+          return [{ id: 'revid', content: 'some review content' }];
         }
       }
     }
@@ -1792,7 +1793,7 @@ Test('delegateToComponent - with errors (selection set order doesnt matter)', as
     schema: composite.schema,
     contextValue: {}
   });
-  t.equal,(result.data.abc, null, 'abc query resolves as expected');
+  t.equal, (result.data.abc, null, 'abc query resolves as expected');
   t.equal(result.data.bca, null, 'bca query resolves as expected');
   t.equal(result.errors.length, 2, '2 errors returned');
   t.equal(result.errors[0].message, result.errors[1].message, 'error messages are equal (Foo.b not nullable) regardless of differing selection set ordering');
@@ -1887,7 +1888,7 @@ Test('delegateToComponent - errors merged as expected for non-nullable list that
     resolvers: {
       Query: {
         foos() {
-          return [ { a: 'bar'} , {}, { a: 'baz'} ];
+          return [{ a: 'bar' }, {}, { a: 'baz' }];
         }
       }
     }
@@ -2097,7 +2098,7 @@ Test(`delegateToComponent - variable in outer query for type that doesn't exist 
   });
 
   t.notOk(result.errors, 'no errors');
-  t.deepEqual(result.data.b, { a: { aField: 'aField'}, bField: 'bField' }, 'result resolved as expected');
+  t.deepEqual(result.data.b, { a: { aField: 'aField' }, bField: 'bField' }, 'result resolved as expected');
   t.end();
 });
 
@@ -2183,7 +2184,7 @@ Test(`delegateToComponent - variables are present in delegated selection set`, a
   });
 
   t.notOk(result.errors, 'no errors');
-  t.deepEqual(result.data.b, { a: { aField: 'aField'}, bField: 'bField' }, 'result resolved as expected');
+  t.deepEqual(result.data.b, { a: { aField: 'aField' }, bField: 'bField' }, 'result resolved as expected');
   t.end();
 });
 
@@ -2207,7 +2208,7 @@ Test('delegateToComponent - delegated selection set from root resolver contains 
         a(_root, _args, _context, info) {
           t.equal(info.fieldNodes[0].selectionSet.selections.length, 1, 'only 1 field in the selection set');
           t.equal(info.fieldNodes[0].selectionSet.selections[0].name.value, 'aField1', 'expected only aField1 in selection set');
-          return { aField1: 'aField1'}
+          return { aField1: 'aField1' }
         }
       }
     }
@@ -2231,7 +2232,7 @@ Test('delegateToComponent - delegated selection set from root resolver contains 
             contextValue: context,
             targetRootField: 'a'
           })
-          return { ...a, b: { bField: 'bField' }};
+          return { ...a, b: { bField: 'bField' } };
         }
       }
     },
@@ -2259,7 +2260,7 @@ Test('delegateToComponent - delegated selection set from root resolver contains 
     }
   });
   t.notOk(result.errors, 'no errors');
-  t.deepEquals(result.data, { aById: { aField1: 'aField1', b: { bField: 'bField'}}}, 'result resolved as expected');
+  t.deepEquals(result.data, { aById: { aField1: 'aField1', b: { bField: 'bField' } } }, 'result resolved as expected');
   t.end();
 });
 
@@ -2279,7 +2280,7 @@ Test('delegateToComponent - delegated selection set from non-root resolver conta
         a(_root, _args, _context, info) {
           t.equal(info.fieldNodes[0].selectionSet.selections.length, 1, 'only 1 field in the selection set');
           t.equal(info.fieldNodes[0].selectionSet.selections[0].name.value, 'aField1', 'expected only aField1 in selection set');
-          return { aField1: 'aField1'};
+          return { aField1: 'aField1' };
         }
       }
     }
@@ -2312,7 +2313,7 @@ Test('delegateToComponent - delegated selection set from non-root resolver conta
             contextValue: context,
             info
           });
-          return {...a, aPrimeField1: 'aPrimeField1'};
+          return { ...a, aPrimeField1: 'aPrimeField1' };
         }
       }
     },
@@ -2336,6 +2337,6 @@ Test('delegateToComponent - delegated selection set from non-root resolver conta
     contextValue: {}
   });
   t.notOk(result.errors, 'no errors');
-  t.deepEquals(result.data, { b: { a: { aField1: 'aField1', aPrimeField1: 'aPrimeField1'}}}, 'result resolved as expected');
+  t.deepEquals(result.data, { b: { a: { aField1: 'aField1', aPrimeField1: 'aPrimeField1' } } }, 'result resolved as expected');
   t.end();
 });

--- a/lib/resolvers/index.js
+++ b/lib/resolvers/index.js
@@ -162,12 +162,7 @@ const wrapNonRootTypeResolvers = function (resolvers) {
         // is present in the root result and if so return it instead of running the
         // actual field resolver
         else {
-          result[type][field] = function (root, ...args) {
-            if (root[field]) {
-              return root[field];
-            }
-            return resolver(root, ...args);
-          }
+          result[type][field] = resolver;
         }
       }
     }
@@ -192,4 +187,4 @@ const importResolvers = function (component, excludes) {
   return wrapNonRootTypeResolvers(filteredResolvers);
 }
 
-module.exports = { memoize, filterResolvers, bindResolvers, importResolvers};
+module.exports = { memoize, filterResolvers, bindResolvers, importResolvers };


### PR DESCRIPTION
After some discussion, for now, and to unblock some efforts that depend on trivial resolvers working correctly, we're undoing the field resolver wrapping meant to protect against double executions in `delegateToComponent` situations.

