### PR TITLE
[SPXCORE-19] Upgrade federation for Node 18 compatibility

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [18.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v3.1.1
+
+- Updated @apollo/federation dependency for Node 18 compatibility
+
 ### v3.1.0
 
 - Updated graphql-tools dependency to fix security vulnerabilities
@@ -10,7 +14,7 @@
 
 - [FIXED] - imported components directives are merged into final schema
 
-### v3.0.2 
+### v3.0.2
 
 - schema pruning and remove broken makeExecutableSchema override
 
@@ -41,7 +45,7 @@
 
 ### v2.1.4
 
-- [REVERT] - reverting both fixes in [2.1.2](https://github.com/ExpediaGroup/graphql-component/releases/tag/v2.1.2). The change made to unify exclusions and return pre-computed results from non-root resolvers resulted in non-root resolvers not executing when they should have.  Being able to exclude non-root resolvers (not their types) is a valid work around in certain situations.
+- [REVERT] - reverting both fixes in [2.1.2](https://github.com/ExpediaGroup/graphql-component/releases/tag/v2.1.2). The change made to unify exclusions and return pre-computed results from non-root resolvers resulted in non-root resolvers not executing when they should have. Being able to exclude non-root resolvers (not their types) is a valid work around in certain situations.
 
 ### v2.1.3
 
@@ -72,7 +76,7 @@
 ### v2.0.3
 
 - [FIXED] individual field exclusions during import - individual field exclusions will no longer modify the original resolver map that is being imported.
-- [FIXED] tightened up argument forwarding when using `delegateToComponent()` - only arguments the target field is expecting   will be extracted from the calling resolver or from the `args` object provided to `delegateToComponent()` depending on the situation. Previously, there were some unintended argument leakage in certain edge cases.
+- [FIXED] tightened up argument forwarding when using `delegateToComponent()` - only arguments the target field is expecting will be extracted from the calling resolver or from the `args` object provided to `delegateToComponent()` depending on the situation. Previously, there were some unintended argument leakage in certain edge cases.
 
 ### v2.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-### v3.1.1
+### v4.0.0
 
-- Updated @apollo/federation dependency for Node 18 compatibility
+- Updated @apollo/federation dependency for Node 18 compatibility.
+- Drop Node 12 compatibility.
 
 ### v3.1.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-component",
-  "version": "3.1.1",
+  "version": "4.0.0",
   "description": "Build, customize and compose GraphQL schemas in a componentized fashion",
   "keywords": [
     "graphql",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-component",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Build, customize and compose GraphQL schemas in a componentized fashion",
   "keywords": [
     "graphql",
@@ -21,7 +21,7 @@
   "repository": "https://github.com/ExpediaGroup/graphql-component",
   "license": "MIT",
   "dependencies": {
-    "@apollo/federation": "^0.28.0",
+    "@apollo/federation": "^0.38.1",
     "@graphql-tools/delegate": "^8.8.1",
     "@graphql-tools/merge": "^8.3.1",
     "@graphql-tools/mock": "^8.7.1",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `main` branch.
* [x] You've successfully built and run the tests locally.
* [x] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- Upgrade `@apollo/federation` package to a version that's compatible with Node 18
   - This helps facilitate Catalyst 12 migration
- This drops compatibility with Node 12 which has been out of support [since April 2022](https://endoflife.date/nodejs).

### :mag: Testing
- Ran federated example locally and confirmed it works as expected.
- Pulled locally into my consuming package and ran `npm i` to confirm compatibility with Node 18.
- Ran unit tests locally on Node 18.
