### PR TITLE
Update @graphql-tools/utils dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v5.0.1
+
+- Update @graphql-tools/utils dependency and fix samples for Apollo server v3.
+
 ### v5.0.0
 
 - Update graphql peer-dependency for Apollo server v3.

--- a/examples/federation/reviews-service/index.js
+++ b/examples/federation/reviews-service/index.js
@@ -5,6 +5,7 @@ const GraphQLComponent = require('../../../lib');
 const ReviewsDataSource = require('./datasource');
 const resolvers = require('./resolvers');
 const types = require('./types');
+const toUppercaseDirective = require('./toUppercaseDirective')
 
 class ReviewsComponent extends GraphQLComponent {
   constructor(options) {
@@ -17,6 +18,9 @@ const run = async function () {
     types,
     resolvers,
     dataSources: [new ReviewsDataSource()],
+    directives: {
+      toUppercase: toUppercaseDirective
+    },
     federation: true
   });
 

--- a/examples/federation/reviews-service/schema.graphql
+++ b/examples/federation/reviews-service/schema.graphql
@@ -1,6 +1,8 @@
+directive @toUppercase on FIELD_DEFINITION
+
 type Review {
   id: ID!
-  content: String!
+  content: String! @toUppercase
 }
 
 extend type Property @key(fields: "id") {

--- a/examples/federation/reviews-service/toUppercaseDirective.js
+++ b/examples/federation/reviews-service/toUppercaseDirective.js
@@ -1,0 +1,25 @@
+const {getDirective, MapperKind, mapSchema} = require("@graphql-tools/utils");
+const {defaultFieldResolver} = require("graphql");
+
+function toUppercaseDirective(directiveName) {
+    return (schema) => mapSchema(schema, {
+        [MapperKind.OBJECT_FIELD]: (fieldConfig) => {
+            const upperDirective = getDirective(schema, fieldConfig, directiveName)?.[0];
+            if (upperDirective) {
+                const {resolve = defaultFieldResolver} = fieldConfig;
+                return {
+                    ...fieldConfig,
+                    resolve: async function (source, args, context, info) {
+                        const result = await resolve(source, args, context, info);
+                        if (typeof result === 'string') {
+                            return result.toUpperCase();
+                        }
+                        return result;
+                    }
+                }
+            }
+        }
+    })
+}
+
+module.exports = toUppercaseDirective

--- a/lib/__tests__.js
+++ b/lib/__tests__.js
@@ -3,8 +3,9 @@
 const Test = require('tape');
 const graphql = require('graphql');
 const gql = require('graphql-tag');
-const { SchemaDirectiveVisitor } = require('@graphql-tools/utils');
+const { SchemaDirectiveVisitor, MapperKind, mapSchema, getDirective} = require('@graphql-tools/utils');
 const GraphQLComponent = require('.');
+const {defaultFieldResolver} = require("graphql/index");
 
 Test('GraphQLComponent instance API (getters/setters)', (t) => {
 
@@ -1109,11 +1110,17 @@ Test(`importing root specifies 'federation: true' results in all components crea
 })
 
 Test('federated schema can include custom directive', (t) => {
-  class CustomDirective extends SchemaDirectiveVisitor {
-    // required for our dummy "custom" directive (ie. implement the SchemaDirectiveVisitor interface)
-    visitFieldDefinition() {
-      return;
-    }
+  function customDirective(directiveName) {
+    return (schema) => mapSchema(schema, {
+      [MapperKind.OBJECT_FIELD]: (fieldConfig) => {
+        const directive = getDirective(schema, fieldConfig, directiveName)?.[0]
+        if (directive) {
+          return {
+            ...fieldConfig,
+          }
+        }
+      }
+    })
   }
 
   const component = new GraphQLComponent({
@@ -1142,7 +1149,7 @@ Test('federated schema can include custom directive', (t) => {
         }
       },
     },
-    directives: { custom: CustomDirective },
+    directives: { custom: customDirective },
     federation: true
   });
 
@@ -1163,7 +1170,7 @@ Test('federated schema can include custom directive', (t) => {
     t.plan(2);
     const { schema: { _typeMap: { Extended } } } = component;
     t.equals(Extended.extensionASTNodes.length, 1, 'Extension AST Nodes is defined');
-    t.equals(Extended.extensionASTNodes[0].fields.filter((field) => field.name.value === "id" && field.directives[0].name.value === "external").length, 1, `id field marked external`);
+    t.equals(Extended.astNode.fields.filter((field) => field.name.value === "id" && field.directives[0].name.value === "external").length, 1, `id field marked external`);
   });
 });
 

--- a/lib/__tests__.js
+++ b/lib/__tests__.js
@@ -3,9 +3,8 @@
 const Test = require('tape');
 const graphql = require('graphql');
 const gql = require('graphql-tag');
-const { SchemaDirectiveVisitor, MapperKind, mapSchema, getDirective} = require('@graphql-tools/utils');
+const { MapperKind, mapSchema, getDirective} = require('@graphql-tools/utils');
 const GraphQLComponent = require('.');
-const {defaultFieldResolver} = require("graphql/index");
 
 Test('GraphQLComponent instance API (getters/setters)', (t) => {
 
@@ -1113,7 +1112,8 @@ Test('federated schema can include custom directive', (t) => {
   function customDirective(directiveName) {
     return (schema) => mapSchema(schema, {
       [MapperKind.OBJECT_FIELD]: (fieldConfig) => {
-        const directive = getDirective(schema, fieldConfig, directiveName)?.[0]
+        const directives = getDirective(schema, fieldConfig, directiveName)
+        const directive = directives && directives[0]
         if (directive) {
           return {
             ...fieldConfig,

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ const { mergeTypeDefs } = require('@graphql-tools/merge');
 const { addMocksToSchema } = require('@graphql-tools/mock');
 const { makeExecutableSchema } = require('@graphql-tools/schema');
 const { delegateToSchema } = require('@graphql-tools/delegate');
-const { pruneSchema, SchemaDirectiveVisitor } = require('@graphql-tools/utils');
+const { pruneSchema } = require('@graphql-tools/utils');
 
 const { bindResolvers } = require('./resolvers');
 const { wrapContext, createContext } = require('./context');

--- a/lib/index.js
+++ b/lib/index.js
@@ -102,11 +102,13 @@ class GraphQLComponent {
   _getMakeSchemaFunction() {
     if (this._federation) {
       return (schemaConfig) => {
-        const schema = buildFederatedSchema(schemaConfig);
+        let schema = buildFederatedSchema(schemaConfig);
 
         // allows a federated schema to have custom directives using the old class based directive implementation
         if (this._directives) {
-          SchemaDirectiveVisitor.visitSchemaDirectives(schema, this._directives);
+          for (const name in this._directives) {
+            schema = this._directives[name](name)(schema)
+          }
         }
         
         return schema;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-component",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Build, customize and compose GraphQL schemas in a componentized fashion",
   "keywords": [
     "graphql",
@@ -27,7 +27,7 @@
     "@graphql-tools/mock": "^8.7.1",
     "@graphql-tools/schema": "^8.5.1",
     "@graphql-tools/stitch": "^8.7.1",
-    "@graphql-tools/utils": "^7.10.0",
+    "@graphql-tools/utils": "^8.6.10",
     "@graphql-tools/wrap": "^8.5.1",
     "debug": "^4.3.1"
   },
@@ -35,11 +35,11 @@
     "graphql": "^16.0.0"
   },
   "devDependencies": {
-    "@apollo/gateway": "^0.28.2",
+    "@apollo/gateway": "^2.7.1",
     "apollo-server": "^3.13.0",
     "casual": "^1.6.0",
     "eslint": "^6.5.1",
-    "graphql": "^15.0.0",
+    "graphql": "^16.0.0",
     "graphql-tag": "^2.12.4",
     "nyc": "^14.1.1",
     "sinon": "^12.0.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "apollo-server": "^3.13.0",
     "casual": "^1.6.0",
     "eslint": "^6.5.1",
-    "graphql": "^16.0.0",
+    "graphql": "^16.8.1",
     "graphql-tag": "^2.12.4",
     "nyc": "^14.1.1",
     "sinon": "^12.0.1",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- Update dependency on `@graphql-tools/utils` to fit the update to `graphql@16`
- Replace the deprecated `SchemaDirectiveVisitor` with `mapSchema` and update the sample

